### PR TITLE
Incorrectly handled BGWH_STOPPED from WaitForBackgroundWorkerStartup

### DIFF
--- a/pg_background.c
+++ b/pg_background.c
@@ -227,13 +227,9 @@ pg_background_launch(PG_FUNCTION_ARGS)
 			/* Success. */
 			break;
 		case BGWH_STOPPED:
-			pfree(worker_handle);
-			ereport(ERROR,
-					(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
-					 errmsg("could not start background process"),
-					 errhint("More details may be available in the server log.")));
+			/* Success and already done. */
 			break;
-        case BGWH_POSTMASTER_DIED:
+		case BGWH_POSTMASTER_DIED:
 			pfree(worker_handle);
 			ereport(ERROR,
 					(errcode(ERRCODE_INSUFFICIENT_RESOURCES),

--- a/pg_background.c
+++ b/pg_background.c
@@ -330,7 +330,7 @@ pg_background_result(PG_FUNCTION_ARGS)
 			{
 				Oid	receive_function_id;
 
-				getTypeBinaryInputInfo(funcctx->tuple_desc->attrs[i]->atttypid,
+				getTypeBinaryInputInfo(funcctx->tuple_desc->attrs[i].atttypid,
 									   &receive_function_id,
 									   &state->typioparams[i]);
 				fmgr_info(receive_function_id, &state->receive_functions[i]);
@@ -437,13 +437,13 @@ pg_background_result(PG_FUNCTION_ARGS)
 
                                                 if (exists_binary_recv_fn(type_id))
                                                 {
-                                                        if (type_id != tupdesc->attrs[i]->atttypid)
+                                                        if (type_id != tupdesc->attrs[i].atttypid)
                                                                 ereport(ERROR,
                                                                                 (errcode(ERRCODE_DATATYPE_MISMATCH),
                                                                                  errmsg("remote query result rowtype does not match "
                                                                                                 "the specified FROM clause rowtype")));
                                                 }
-                                                else if(tupdesc->attrs[i]->atttypid != TEXTOID)
+                                                else if(tupdesc->attrs[i].atttypid != TEXTOID)
                                                         ereport(ERROR,
                                                                         (errcode(ERRCODE_DATATYPE_MISMATCH),
                                                                          errmsg("remote query result rowtype does not match "
@@ -507,7 +507,7 @@ pg_background_result(PG_FUNCTION_ARGS)
 	/* If no data rows, return the command tags instead. */
 	if (!state->has_row_description)
 	{
-		if (tupdesc->natts != 1 || tupdesc->attrs[0]->atttypid != TEXTOID)
+		if (tupdesc->natts != 1 || tupdesc->attrs[0].atttypid != TEXTOID)
 			ereport(ERROR,
 					(errcode(ERRCODE_DATATYPE_MISMATCH),
 					 errmsg("remote query did not return a result set, but "
@@ -566,7 +566,7 @@ form_result_tuple(pg_background_result_state *state, TupleDesc tupdesc,
 			values[i] = ReceiveFunctionCall(&state->receive_functions[i],
 											NULL,
 											state->typioparams[i],
-											tupdesc->attrs[i]->atttypmod);
+											tupdesc->attrs[i].atttypmod);
 			isnull[i] = true;
 		}
 		else
@@ -576,7 +576,7 @@ form_result_tuple(pg_background_result_state *state, TupleDesc tupdesc,
 			values[i] = ReceiveFunctionCall(&state->receive_functions[i],
 											&buf,
 											state->typioparams[i],
-											tupdesc->attrs[i]->atttypmod);
+											tupdesc->attrs[i].atttypmod);
 			isnull[i] = false;
 		}
 	}
@@ -805,7 +805,7 @@ pg_background_worker_main(Datum main_arg)
 	 * rather than strings.
 	 */
         BackgroundWorkerInitializeConnection(NameStr(fdata->database),
-                                                                                 NameStr(fdata->authenticated_user));
+                                                                                 NameStr(fdata->authenticated_user), 0);
 
 	if (fdata->database_id != MyDatabaseId ||
 		fdata->authenticated_user_id != GetAuthenticatedUserId())


### PR DESCRIPTION
BGWH_STOPPED does not mean that the background process could not have been started, but it means it already exited - see the relevant documentation part: https://www.postgresql.org/docs/current/bgworker.html, there is no indication that error should be raised for such a return value:
> ... and BGWH_STOPPED indicates that it has been started but is no longer running

In our environment, pg_background_launch unpredictably and very rarely failed when BGWH_STOPPED branch was matched ("could not start background process" was reported in the log and it is the only place in the code with this message), but the process results were present and OK.