### PR TITLE
Fix warning due to -Wimplicit-fallthrough flag.

### DIFF
--- a/pg_background.c
+++ b/pg_background.c
@@ -496,14 +496,15 @@ pg_background_result(PG_FUNCTION_ARGS)
 					MemoryContextSwitchTo(oldcontext);
 					break;
 				}
-                        case 'G':
-                        case 'H':
-                        case 'W':
-                                {
-                                        ereport(ERROR,
-                                                        (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-                                                         errmsg("COPY protocol not allowed in pg_background")));
-                                }
+			case 'G':
+			case 'H':
+			case 'W':
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("COPY protocol not allowed in pg_background")));
+					break;
+				}
 			case 'Z':
 				{
 					/* Handle ReadyForQuery message. */


### PR DESCRIPTION
This flag has been added by default in PG13, and it seems that some compilers
don't realize that erreport(ERROR,...) will actually throw an error.