### PR TITLE
Fix compatibility with pg14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ OBJS = pg_background.o
 
 EXTENSION = pg_background
 DATA = pg_background--1.0.sql
+REGRESS = pg_background
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/expected/pg_background.out
+++ b/expected/pg_background.out
@@ -1,0 +1,14 @@
+CREATE EXTENSION pg_background;
+CREATE TABLE t(id integer);
+SELECT * FROM pg_background_result(pg_background_launch('INSERT INTO t SELECT 1')) AS (result TEXT);
+   result   
+------------
+ INSERT 0 1
+(1 row)
+
+SELECT * FROM t;
+ id 
+----
+  1
+(1 row)
+

--- a/pg_background.c
+++ b/pg_background.c
@@ -726,7 +726,7 @@ save_worker_info(pid_t pid, dsm_segment *seg, BackgroundWorkerHandle *handle,
                 ctl.keysize = sizeof(pid_t);
                 ctl.entrysize = sizeof(pg_background_worker_info);
                 worker_hash = hash_create("pg_background worker_hash", 8, &ctl,
-                                                                  HASH_ELEM);
+                                          HASH_BLOBS | HASH_ELEM);
         }
 
         /* Get current authentication information. */

--- a/sql/pg_background.sql
+++ b/sql/pg_background.sql
@@ -1,0 +1,7 @@
+CREATE EXTENSION pg_background;
+
+CREATE TABLE t(id integer);
+
+SELECT * FROM pg_background_result(pg_background_launch('INSERT INTO t SELECT 1')) AS (result TEXT);
+
+SELECT * FROM t;


### PR DESCRIPTION
Hi,

Right now pg_background would compile on pg14 but will fail as hash_create() now requires to explicitly provide a hash method (see the commit message for more details).

I'm also adding some basic regression test to quickly validate that the extension works as expected.