### PR TITLE
Add a pg_background_discard_result() function.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ MODULE_big = pg_background
 OBJS = pg_background.o
 
 EXTENSION = pg_background
-DATA = pg_background--1.0.sql
+DATA = pg_background--1.0.sql \
+       pg_background--1.0--1.1.sql \
+       pg_background--1.1.sql
 REGRESS = pg_background
 
 PG_CONFIG = pg_config

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This module comes with following SQL APIs:
 
 1. ***pg_background_launch*** : This API takes SQL command, which user wants to execute, and size of queue buffer. This function returns the process id of background worker.
 2. ***pg_background_result*** : This API takes the process id as input parameter and returns the result of command executed throught the background worker.
+2. ***pg_background_discard_result*** : This API takes the process id as input parameter and discards the result of command executed throught the background worker, only emitted any error message.
 3. ***pg_background_detach*** : This API takes the process id and detach the background process which is waiting for user to read its results.
 
 ## Installation steps
@@ -39,6 +40,11 @@ SELECT pg_background_launch('SQL COMMAND');
 To fetch the result of command executed background worker, user can use following command:
 ```sql
 SELECT pg_background_result(pid)
+```
+
+Alternatively, to discard the result but still get error messages if any, user can use following command:
+```sql
+SELECT pg_background_discard_result(pid)
 ```
 
 **pid is process id returned by pg_background_launch function**
@@ -111,5 +117,15 @@ CPU 0.00s/0.00u sec elapsed 0.00 sec.
  result 
 --------
  VACUUM
+(1 row)
+```
+
+Or to only get the error data:
+```sql
+SELECT * FROM pg_background_discard_result(pg_background_launch('DROP TABLE IF EXISTS table_to_drop'));
+NOTICE:  table "table_to_drop" does not exist, skipping
+ pg_background_discard_result
+------------------------------
+
 (1 row)
 ```

--- a/expected/pg_background.out
+++ b/expected/pg_background.out
@@ -12,3 +12,10 @@ SELECT * FROM t;
   1
 (1 row)
 
+SELECT * FROM pg_background_discard_result(pg_background_launch($$DROP TABLE IF EXISTS not_a_table; SELECT 1, 'val'$$));
+NOTICE:  table "not_a_table" does not exist, skipping
+ pg_background_discard_result 
+------------------------------
+ 
+(1 row)
+

--- a/pg_background--1.0--1.1.sql
+++ b/pg_background--1.0--1.1.sql
@@ -1,0 +1,7 @@
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION pg_background UPDATE TO '1.1'" to load this file. \quit
+
+
+CREATE FUNCTION pg_background_discard_result(pid pg_catalog.int4)
+    RETURNS void STRICT
+	AS 'MODULE_PATHNAME' LANGUAGE C;

--- a/pg_background--1.1.sql
+++ b/pg_background--1.1.sql
@@ -1,0 +1,25 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION pg_background" to load this file. \quit
+
+CREATE FUNCTION pg_background_launch(sql pg_catalog.text,
+					   queue_size pg_catalog.int4 DEFAULT 65536)
+    RETURNS pg_catalog.int4 STRICT
+	AS 'MODULE_PATHNAME' LANGUAGE C;
+
+CREATE FUNCTION pg_background_discard_result(pid pg_catalog.int4)
+    RETURNS void STRICT
+	AS 'MODULE_PATHNAME' LANGUAGE C;
+
+CREATE FUNCTION pg_background_result(pid pg_catalog.int4)
+    RETURNS SETOF pg_catalog.record STRICT
+	AS 'MODULE_PATHNAME' LANGUAGE C;
+
+CREATE FUNCTION pg_background_detach(pid pg_catalog.int4)
+    RETURNS pg_catalog.void STRICT
+	AS 'MODULE_PATHNAME' LANGUAGE C;
+REVOKE ALL ON FUNCTION pg_background_launch(pg_catalog.text, pg_catalog.int4)
+	FROM public;
+REVOKE ALL ON FUNCTION pg_background_result(pg_catalog.int4)
+	FROM public;
+REVOKE ALL ON FUNCTION pg_background_detach(pg_catalog.int4)
+	FROM public;

--- a/pg_background.control
+++ b/pg_background.control
@@ -1,4 +1,4 @@
 comment = 'Run SQL queries in the background'
-default_version = '1.0'
+default_version = '1.1'
 module_pathname = '$libdir/pg_background'
 relocatable = true

--- a/sql/pg_background.sql
+++ b/sql/pg_background.sql
@@ -5,3 +5,5 @@ CREATE TABLE t(id integer);
 SELECT * FROM pg_background_result(pg_background_launch('INSERT INTO t SELECT 1')) AS (result TEXT);
 
 SELECT * FROM t;
+
+SELECT * FROM pg_background_discard_result(pg_background_launch($$DROP TABLE IF EXISTS not_a_table; SELECT 1, 'val'$$));


### PR DESCRIPTION
This function will consume all protocol messages, discard all data and will only rethrow any error data emitted during the background query execution.

This allows users to execute any kind of SQL without worrying of specifying a column definition list matching the last emitted resultset if they're not interested in the resultset, but still want to actively wait for the background execution completion and want know if any error happened during the background execution.