### PR TITLE
add PGDLLEXPORT to pg_background_work_main for pg16

### DIFF
--- a/pg_background.c
+++ b/pg_background.c
@@ -113,7 +113,7 @@ PG_FUNCTION_INFO_V1(pg_background_launch);
 PG_FUNCTION_INFO_V1(pg_background_result);
 PG_FUNCTION_INFO_V1(pg_background_detach);
 
-void pg_background_worker_main(Datum);
+PGDLLEXPORT void pg_background_worker_main(Datum);
 
 /*
  * Start a dynamic background worker to run a user-specified SQL command.


### PR DESCRIPTION
Postgres 16 includes a change to the extension framework:

```
Functions that need to be called from the core backend or other extensions must now be explicitly marked PGDLLEXPORT.
```