### PR TITLE
Fixing the changes for REL_18_STABLE branch

### DIFF
--- a/pg_background.c
+++ b/pg_background.c
@@ -1033,11 +1033,7 @@ execute_sql_string(const char *sql)
 		portal = CreatePortal("", true, true);
 		/* Don't display the portal in pg_cursors */
 		portal->visible = false;
-#if PG_VERSION_NUM < 180000
-                PortalDefineQuery(portal, NULL, sql, commandTag, plantree_list, NULL);
-#else
-                PortalDefineQuery(portal, NULL, sql, commandTag, plantree_list, NULL, NULL);
-#endif
+        PortalDefineQuery(portal, NULL, sql, commandTag, plantree_list, NULL);
 		PortalStart(portal, NULL, 0, InvalidSnapshot);
 		PortalSetResultFormat(portal, 1, &format);	/* binary format */
 

--- a/pg_background.h
+++ b/pg_background.h
@@ -7,8 +7,10 @@
  * TupleDescAttr was introduced in 9.6.5 and 9.5.9, so allow compilation
  * against those versions just in case.
  */
+#if PG_VERSION_NUM < 180000
 #ifndef TupleDescAttr
 #define TupleDescAttr(tupdesc, i) (&(tupdesc)->attrs[(i)])
+#endif
 #endif
 
 #if PG_VERSION_NUM < 100000


### PR DESCRIPTION
There were some issues with the previous release, mainly due to differences between the APIs of Beta1 and the REL_18_STABLE release branch. This PR fixes those.