### PR TITLE
Fix use transactional function out of transaction

### DIFF
--- a/pg_background.c
+++ b/pg_background.c
@@ -861,9 +861,6 @@ pg_background_worker_main(Datum main_arg)
 	RestoreGUCState(gucstate);
 	CommitTransactionCommand();
 
-	/* Restore user ID and security context. */
-	SetUserIdAndSecContext(fdata->current_user_id, fdata->sec_context);
-
 	/* Prepare to execute the query. */
 	SetCurrentStatementStartTimestamp();
 	debug_query_string = sql;
@@ -873,6 +870,9 @@ pg_background_worker_main(Datum main_arg)
 		enable_timeout_after(STATEMENT_TIMEOUT, StatementTimeout);
 	else
 		disable_timeout(STATEMENT_TIMEOUT, false);
+
+	/* Restore user ID and security context. */
+	SetUserIdAndSecContext(fdata->current_user_id, fdata->sec_context);
 
 	/* Execute the query. */
 	execute_sql_string(sql);


### PR DESCRIPTION
'SetUserIdAnsSecContext' function is transactional, so must be called in transaction, but in current implementation it is invoked between 2 transactions.

The problem arises when Assert checking is enabled. Then 'Assert(s->prevSecContext == 0)' assert is failed in 'StartTransactionCommand'.

To fix this just move appropriate function below, after transaction is started.