### PR TITLE
fix: switch memory context before CopyErrorData in worker error handler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,11 +255,35 @@ jobs:
       - name: Run upgrade test
         run: ./test-upgrade.sh 17
 
+  # Test with assert-enabled PostgreSQL (catches memory context bugs)
+  assert-test:
+    name: Assert-Enabled Test (PG ${{ matrix.pg }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        pg: [14, 17]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run assert-enabled test
+        run: ./test-assert.sh ${{ matrix.pg }}
+
+      - name: Show logs on failure
+        if: failure()
+        run: |
+          echo "=== Test failed - check logs above for assertion failures ==="
+          echo "Common assertion: FailedAssertion(\"CurrentMemoryContext != ErrorContext\")"
+
   # Summary job that depends on all test matrix jobs
   test-summary:
     name: Test Summary
     runs-on: ubuntu-24.04
-    needs: [test, relocatable-test, upgrade-test]
+    needs: [test, relocatable-test, upgrade-test, assert-test]
     if: always()
     steps:
       - name: Check test results
@@ -274,6 +298,10 @@ jobs:
           fi
           if [ "${{ needs.upgrade-test.result }}" != "success" ]; then
             echo "::error::Upgrade test failed"
+            exit 1
+          fi
+          if [ "${{ needs.assert-test.result }}" != "success" ]; then
+            echo "::error::Assert-enabled test failed (memory context bug detected)"
             exit 1
           fi
           echo "All test jobs passed!"

--- a/pg_background.c
+++ b/pg_background.c
@@ -2539,8 +2539,18 @@ pg_background_worker_main(Datum main_arg)
     }
     PG_CATCH();
     {
-        /* v1.9: Capture structured error info before re-throwing */
-        ErrorData *edata = CopyErrorData();
+        ErrorData *edata;
+
+        /*
+         * v1.9: Capture structured error info before re-throwing.
+         *
+         * IMPORTANT: Must switch out of ErrorContext before calling
+         * CopyErrorData(). PostgreSQL's CopyErrorData() allocates the copy
+         * in CurrentMemoryContext, and asserts that it's not ErrorContext
+         * (to prevent use-after-free when ErrorContext is reset on next error).
+         */
+        MemoryContextSwitchTo(TopMemoryContext);
+        edata = CopyErrorData();
 
         /*
          * Clear result metadata to avoid stale values from earlier successful

--- a/test-assert.sh
+++ b/test-assert.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+#
+# Test pg_background against assert-enabled PostgreSQL build
+# This reproduces the FailedAssertion in CopyErrorData on error paths
+#
+
+set -e
+
+PG_VERSION="${1:-14}"
+CONTAINER_NAME="pg_background_assert_test_pg${PG_VERSION}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+step() { echo -e "${BLUE}[STEP]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+cleanup() {
+    info "Cleaning up container: ${CONTAINER_NAME}"
+    docker rm -f "${CONTAINER_NAME}" 2>/dev/null || true
+}
+
+trap cleanup EXIT
+
+echo "========================================"
+info "Testing with PostgreSQL ${PG_VERSION} (ASSERT-ENABLED)"
+echo "========================================"
+
+cleanup
+
+step "Starting Debian container for PostgreSQL build..."
+docker run -d \
+    --name "${CONTAINER_NAME}" \
+    -e POSTGRES_HOST_AUTH_METHOD=trust \
+    debian:bookworm-slim \
+    sleep infinity
+
+step "Installing build dependencies..."
+docker exec "${CONTAINER_NAME}" bash -c "
+    apt-get update -qq
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+        build-essential \
+        libreadline-dev \
+        zlib1g-dev \
+        flex \
+        bison \
+        libxml2-dev \
+        libxslt1-dev \
+        libssl-dev \
+        libxml2-utils \
+        xsltproc \
+        pkg-config \
+        wget \
+        sudo \
+        locales \
+        > /dev/null
+
+    # Set up locale
+    sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen
+    locale-gen
+"
+
+step "Downloading PostgreSQL ${PG_VERSION} source..."
+docker exec "${CONTAINER_NAME}" bash -c "
+    cd /tmp
+    wget -q https://ftp.postgresql.org/pub/source/v${PG_VERSION}.0/postgresql-${PG_VERSION}.0.tar.gz || \
+    wget -q https://ftp.postgresql.org/pub/source/v${PG_VERSION}.1/postgresql-${PG_VERSION}.1.tar.gz || \
+    wget -q https://ftp.postgresql.org/pub/source/v${PG_VERSION}.2/postgresql-${PG_VERSION}.2.tar.gz || \
+    wget -q https://ftp.postgresql.org/pub/source/v${PG_VERSION}.21/postgresql-${PG_VERSION}.21.tar.gz || \
+    wget -q https://ftp.postgresql.org/pub/source/v${PG_VERSION}.22/postgresql-${PG_VERSION}.22.tar.gz
+    tar xzf postgresql-*.tar.gz
+"
+
+step "Building PostgreSQL with --enable-cassert (assertions enabled)..."
+docker exec "${CONTAINER_NAME}" bash -c '
+    PG_SRC=$(ls -d /tmp/postgresql-*/)
+    cd "$PG_SRC"
+    ./configure \
+        --enable-cassert \
+        --enable-debug \
+        --prefix=/usr/local/pgsql \
+        --with-openssl \
+        > /dev/null
+    make -j$(nproc) > /dev/null 2>&1
+    make install > /dev/null
+'
+
+step "Setting up PostgreSQL user and data directory..."
+docker exec "${CONTAINER_NAME}" bash -c "
+    useradd -m postgres || true
+    mkdir -p /usr/local/pgsql/data
+    chown postgres:postgres /usr/local/pgsql/data
+
+    # Initialize database
+    sudo -u postgres /usr/local/pgsql/bin/initdb -D /usr/local/pgsql/data
+
+    # Configure for testing
+    echo \"shared_preload_libraries = ''\" >> /usr/local/pgsql/data/postgresql.conf
+    echo \"max_worker_processes = 16\" >> /usr/local/pgsql/data/postgresql.conf
+    echo \"log_min_messages = warning\" >> /usr/local/pgsql/data/postgresql.conf
+"
+
+step "Starting PostgreSQL..."
+docker exec "${CONTAINER_NAME}" bash -c "
+    sudo -u postgres /usr/local/pgsql/bin/pg_ctl -D /usr/local/pgsql/data -l /tmp/pg.log start
+    sleep 2
+    sudo -u postgres /usr/local/pgsql/bin/createdb regression || true
+"
+
+step "Verifying PostgreSQL is assert-enabled..."
+docker exec "${CONTAINER_NAME}" bash -c "
+    sudo -u postgres /usr/local/pgsql/bin/psql -c \"SHOW debug_assertions;\" regression
+"
+
+step "Copying pg_background source to container..."
+docker cp . "${CONTAINER_NAME}:/tmp/pg_background"
+
+step "Building pg_background extension..."
+docker exec "${CONTAINER_NAME}" bash -c "
+    cd /tmp/pg_background
+    export PATH=/usr/local/pgsql/bin:\$PATH
+    make clean
+    make
+    make install
+"
+
+step "Running regression tests (expecting failure on error path)..."
+set +e  # Don't exit on test failure - we expect it might fail
+
+docker exec "${CONTAINER_NAME}" bash -c '
+    cd /tmp/pg_background
+    export PATH=/usr/local/pgsql/bin:$PATH
+    chown -R postgres:postgres /tmp/pg_background
+    sudo -u postgres env PATH=/usr/local/pgsql/bin:$PATH make installcheck 2>&1
+'
+TEST_RESULT=$?
+
+set -e
+
+if [ $TEST_RESULT -eq 0 ]; then
+    info "All tests PASSED on assert-enabled PostgreSQL ${PG_VERSION}"
+else
+    error "Tests FAILED on assert-enabled PostgreSQL ${PG_VERSION}"
+
+    step "Checking for assertion failures in logs..."
+    docker exec "${CONTAINER_NAME}" bash -c "
+        echo '=== PostgreSQL Log (last 50 lines) ==='
+        tail -50 /tmp/pg.log || true
+        echo ''
+        echo '=== Regression Diffs ==='
+        cat /tmp/pg_background/regression.diffs 2>/dev/null || echo 'No diffs file'
+    "
+fi
+
+exit $TEST_RESULT


### PR DESCRIPTION
## Summary

- Fix assertion failure on assert-enabled PostgreSQL builds (Debian unstable packages)
- Add `test-assert.sh` for testing with `--enable-cassert` PostgreSQL builds
- Add CI job to catch memory context bugs early

## Problem

The v1.9 structured error capture code was calling `CopyErrorData()` directly inside `PG_CATCH()` without switching memory contexts first. PostgreSQL's `CopyErrorData()` asserts that `CurrentMemoryContext != ErrorContext` to prevent use-after-free bugs.

This caused crashes on assert-enabled builds:

```
TRAP: FailedAssertion("CurrentMemoryContext != ErrorContext", File: "elog.c", Line: 1575)
LOG:  background worker "pg_background" (PID 1373) was terminated by signal 6: Aborted
DETAIL:  Failed process was running: SELECT 1/0
```

## Fix

Add `MemoryContextSwitchTo(TopMemoryContext)` before calling `CopyErrorData()`, following standard PostgreSQL error handling patterns.

## Test plan

- [x] All Docker tests pass (PG 14, 15, 16, 17, 18)
- [x] Assert-enabled PG 14 test passes
- [x] Assert-enabled PG 17 test passes
- [ ] CI pipeline validates fix

## Files changed

| File | Change |
|------|--------|
| `pg_background.c` | Add memory context switch before `CopyErrorData()` |
| `test-assert.sh` | New script for assert-enabled PostgreSQL testing |
| `.github/workflows/ci.yml` | Add assert-test job for PG 14 and 17 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)