### PR TITLE
Fix/worker sqlstate propagation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [14, 17]
+        pg: [14, 15, 16, 17, 18]
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -154,15 +154,18 @@ SELECT extname, extversion FROM pg_extension WHERE extname = 'pg_background';
 
 `pg_background` does **not** require `shared_preload_libraries`. Workers are
 registered dynamically (`RegisterDynamicBackgroundWorker`) and each worker
-process loads the library on its own via `dlopen`.
+process loads the library dynamically when it starts.
 
 Adding `pg_background` to `shared_preload_libraries` is **optional** and only
 needed if you want the extension's GUC parameters
 (`pg_background.max_workers`, `pg_background.default_queue_size`,
 `pg_background.worker_timeout`) available in `postgresql.conf` and visible in
 all sessions from the start. Without SPL, the GUCs are registered on first
-use (`CREATE EXTENSION`, `LOAD`, or the first `launch_v2` call) and a `SET`
-before that point produces a harmless warning.
+use (`CREATE EXTENSION`, `LOAD`, or the first `launch_v2` call). A session
+`SET` before that point raises an `unrecognized configuration parameter`
+error. The warning behavior applies to configuration file entries (for
+example, `postgresql.conf` or `ALTER SYSTEM`) that are read before the
+library is loaded.
 
 | | Without SPL | With SPL |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -150,6 +150,27 @@ SELECT extname, extversion FROM pg_extension WHERE extname = 'pg_background';
 --  pg_background | 1.9
 ```
 
+### Library Loading
+
+`pg_background` does **not** require `shared_preload_libraries`. Workers are
+registered dynamically (`RegisterDynamicBackgroundWorker`) and each worker
+process loads the library on its own via `dlopen`.
+
+Adding `pg_background` to `shared_preload_libraries` is **optional** and only
+needed if you want the extension's GUC parameters
+(`pg_background.max_workers`, `pg_background.default_queue_size`,
+`pg_background.worker_timeout`) available in `postgresql.conf` and visible in
+all sessions from the start. Without SPL, the GUCs are registered on first
+use (`CREATE EXTENSION`, `LOAD`, or the first `launch_v2` call) and a `SET`
+before that point produces a harmless warning.
+
+| | Without SPL | With SPL |
+|---|---|---|
+| Extension works? | Yes | Yes |
+| GUCs in `postgresql.conf` | Not until first load | Immediately |
+| After `make install` | Workers pick up new `.so` automatically | **Restart required** (postmaster caches the library) |
+| Recommended for | Development, staging, simple setups | Production with tuned GUCs |
+
 ### Custom Schema Installation
 
 The extension is **relocatable**, allowing installation in any schema. This is useful for organizing extensions or avoiding namespace conflicts.
@@ -492,6 +513,108 @@ CREATE TYPE pg_background_error AS (
   context   text    -- Error context/stack trace
 );
 ```
+
+#### Structured Error Returns — SQLSTATE Semantics
+
+`pg_background_error_info_v2(pid, cookie)` returns the **real** five-character
+`SQLSTATE` emitted by the worker's failed statement, not a synthesized
+`08006 "lost connection to worker process"`. The worker's `PG_CATCH` handler
+copies `ErrorData` from the caught `ereport(ERROR)`, stores the fields in DSM
+(with `error_sqlstate` written last as a publish flag) and calls
+`EmitErrorReport()` + `ReadyForQuery(DestRemote)` + `pq_flush()` so the launcher
+sees the actual `'E'` error frame over `shm_mq`.
+
+Typical codes returned end-to-end (v1.9+):
+
+| Trigger SQL                                      | Returned `sqlstate` | Path            |
+|--------------------------------------------------|---------------------|-----------------|
+| `SELECT 1/0`                                     | `22012`             | execute         |
+| `RAISE EXCEPTION 'custom error'`                 | `P0001`             | execute         |
+| `INSERT NULL` into `NOT NULL` column             | `23502`             | execute         |
+| `INSERT` violating `INITIALLY DEFERRED` FK       | `23503`             | commit          |
+| `pg_background_cancel_v2()` during `pg_sleep()`  | `57014`             | execute         |
+
+**Recommended pattern**: call `error_info_v2` from the same PL/pgSQL
+`EXCEPTION` block that observes the failure. Once the launcher's transaction
+aborts, `cleanup_worker_info` removes the hash entry and the next transaction
+will see `ERRCODE_UNDEFINED_OBJECT` ("PID N is not attached to this session").
+
+```sql
+DO $$
+DECLARE
+    h pg_background_handle;
+    s text;
+BEGIN
+    h := pg_background_launch_v2('SELECT 1/0');
+    PERFORM pg_background_wait_v2(h.pid, h.cookie);
+    SELECT sqlstate INTO s
+      FROM pg_background_error_info_v2(h.pid, h.cookie);
+    RAISE NOTICE 'worker sqlstate=%', s;   -- 22012
+    PERFORM pg_background_detach_v2(h.pid, h.cookie);
+END$$;
+```
+
+> **Important — do not call `result_v2()` on an error path.** `result_v2()`
+> re-raises the worker's error in the launcher via `ereport(ERROR)`, which
+> aborts the current transaction and triggers `cleanup_worker_info` before you
+> can inspect `error_info_v2()`. For error diagnosis, the supported pattern is
+> `launch_v2 -> wait_v2 -> error_info_v2 -> detach_v2` (no `result_v2`).
+
+> **`08006` is now reserved for infra-level failures only.** The launcher
+> synthesizes `ERRCODE_CONNECTION_FAILURE "lost connection to worker process"`
+> only when the worker died before it could propagate a real error (see
+> [Known Limitations — Early worker failures](#9-early-worker-failures-before-pq_redirect_to_shm_mq)).
+> Under normal operation, any SQL-level error inside the worker surfaces as
+> the concrete SQLSTATE shown in the table above.
+
+### Deployment Order
+
+The fix for end-to-end SQLSTATE propagation lives in the compiled
+`pg_background.so`. Whether a server restart is required depends on how the
+library is loaded (see [Library Loading](#library-loading)):
+
+- **With `shared_preload_libraries`**: the postmaster dlopens the library
+  once at startup and every forked background worker inherits the cached
+  handle. After replacing the `.so` on disk you must restart PostgreSQL —
+  a plain `pg_reload_conf()` is not sufficient.
+- **Without SPL** (the default): each background worker dlopens the library
+  in its own process, so a fresh `pg_background_launch_v2(...)` call picks
+  up the new binary automatically. No server restart is needed; at most,
+  reconnect long-lived client sessions.
+
+1. Build and install: `make clean && make && sudo make install`.
+2. **Reload the library:**
+   - SPL setup → `pg_ctl restart` / systemd / platform equivalent.
+   - On-demand setup → no action required (optionally reconnect clients).
+3. Verify on staging that real SQLSTATEs propagate:
+   ```sql
+   DO $$
+   DECLARE h pg_background_handle; s text;
+   BEGIN
+       h := pg_background_launch_v2('SELECT 1/0');
+       PERFORM pg_background_wait_v2(h.pid, h.cookie);
+       SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
+       ASSERT s = '22012', 'expected 22012, got ' || s;
+       PERFORM pg_background_detach_v2(h.pid, h.cookie);
+   END$$;
+   ```
+4. **Only after step 3 succeeds**, remove any PL/pgSQL workarounds that read
+   `error_info_v2` as a fallback after catching `08006`. Before the fix ships
+   they were the only way to get a usable SQLSTATE; after the fix they become
+   dead code, but keeping them in place during the rollout is harmless.
+
+### Rollback Order
+
+To roll back to a pre-fix `.so` (for example if another extension in the same
+image regresses):
+
+1. **First** restore the PL/pgSQL workarounds in user code (they expect
+   `SQLERRM` to degrade to `08006` and then read `error_info_v2` out of band).
+2. **Only after step 1**, install the old `.so` and restart PostgreSQL.
+
+Doing rollback in the reverse order (old `.so` first) causes user functions to
+see raw `08006` errors without the fallback path, which can manifest as
+`WHEN others` branches swallowing what used to be diagnosable SQLSTATEs.
 
 ### V1 Functions (Deprecated)
 
@@ -1880,6 +2003,47 @@ WHERE backend_type LIKE '%background%';
 **Impact**: Cannot implement 2PC-like patterns natively.
 
 **Workaround**: Use `dblink` with `PREPARE TRANSACTION` for XA-like semantics.
+
+### 9. Early Worker Failures (Before `pq_redirect_to_shm_mq`)
+
+**Limitation**: Errors raised in the worker **before** `pq_redirect_to_shm_mq()`
+installs the shm_mq destination cannot be captured as a structured error.
+
+**What is "early"**: The small window between worker startup and the
+`pq_redirect_to_shm_mq()` call in `pg_background_worker_main` — primarily:
+
+- Failure to attach the DSM segment (`dsm_attach` returning NULL).
+- `shm_toc_lookup` failure (missing TOC entry — implies an internally
+  inconsistent DSM, typically a sign of server misconfiguration).
+- Out-of-memory during the initial worker setup allocations.
+
+**Observable behavior for the launcher**:
+
+- `pg_background_result_v2()` raises `SQLSTATE 08006 "lost connection to
+  worker process"` when it tries to read results from the detached shm_mq.
+  `pg_background_wait_v2()` blocks on `WaitForBackgroundWorkerShutdown` and
+  returns silently — it does not raise; the early worker exit leaves no
+  structured error on the wire for it to observe.
+- `pg_background_error_info_v2()` returns `NULL` row (no structured info).
+- `pg_background_result_info_v2()` reports `completed=true, has_error=false`
+  since the worker never got far enough to run SQL.
+
+**Why it cannot be captured**: the worker's error-propagation contract
+(`EmitErrorReport` over shm_mq, `ReadyForQuery(DestRemote)`, `pq_flush`)
+requires the shm_mq destination to already be installed. Before
+`pq_redirect_to_shm_mq`, `ereport(ERROR)` goes to the server log only; the
+launcher observes the worker exit and synthesizes `08006`.
+
+**Impact in practice**: these are infrastructure-level failures (DSM OOM,
+misconfigured `dynamic_shared_memory_type`, missing `shm_toc` entry). They
+are rare in a correctly configured server and do not indicate user-level SQL
+problems.
+
+**Recommended handling**: treat a `08006` from `pg_background_result_v2()`
+as an infra signal — do not attempt to parse an `error_info_v2` row that may
+be `NULL`. All ordinary SQL errors (syntax, constraint violation,
+division-by-zero, `RAISE EXCEPTION`, statement cancel) propagate through the
+normal path and appear as their real SQLSTATE, not `08006`.
 
 ---
 

--- a/expected/pg_background.out
+++ b/expected/pg_background.out
@@ -108,7 +108,7 @@ SELECT pg_background_detach(
  
 (1 row)
 
-SELECT pg_sleep(0.2);
+SELECT pg_sleep(1.0);
  pg_sleep 
 ----------
  
@@ -130,7 +130,7 @@ BEGIN
   PERFORM pg_background_detach_v2(h.pid, h.cookie);
 END;
 $$;
-SELECT pg_sleep(0.2);
+SELECT pg_sleep(1.0);
  pg_sleep 
 ----------
  

--- a/expected/pg_background.out
+++ b/expected/pg_background.out
@@ -1093,7 +1093,7 @@ BEGIN
     h := pg_background_launch_v2('SELECT 1/0');
     PERFORM pg_background_wait_v2(h.pid, h.cookie);
     SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
-    IF s <> '22012' THEN
+    IF s IS DISTINCT FROM '22012' THEN
         RAISE EXCEPTION 'test 3.1: expected sqlstate 22012, got %', s;
     END IF;
     PERFORM pg_background_detach_v2(h.pid, h.cookie);
@@ -1112,7 +1112,7 @@ BEGIN
     h := pg_background_launch_v2('SELECT pgbg_test_raise_p0001()');
     PERFORM pg_background_wait_v2(h.pid, h.cookie);
     SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
-    IF s <> 'P0001' THEN
+    IF s IS DISTINCT FROM 'P0001' THEN
         RAISE EXCEPTION 'test 3.2: expected sqlstate P0001, got %', s;
     END IF;
     PERFORM pg_background_detach_v2(h.pid, h.cookie);
@@ -1134,7 +1134,7 @@ BEGIN
     h := pg_background_launch_v2('INSERT INTO pgbg_test_nn_23502 VALUES (NULL)');
     PERFORM pg_background_wait_v2(h.pid, h.cookie);
     SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
-    IF s <> '23502' THEN
+    IF s IS DISTINCT FROM '23502' THEN
         RAISE EXCEPTION 'test 3.3: expected sqlstate 23502, got %', s;
     END IF;
     PERFORM pg_background_detach_v2(h.pid, h.cookie);
@@ -1170,7 +1170,7 @@ BEGIN
     );
     PERFORM pg_background_wait_v2(h.pid, h.cookie);
     SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
-    IF s <> '23503' THEN
+    IF s IS DISTINCT FROM '23503' THEN
         RAISE EXCEPTION 'test 3.4: expected sqlstate 23503, got %', s;
     END IF;
     PERFORM pg_background_detach_v2(h.pid, h.cookie);
@@ -1221,7 +1221,7 @@ BEGIN
         RAISE EXCEPTION 'test 3.5: worker did not stop within 5s after cancel';
     END IF;
     SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
-    IF s <> '57014' THEN
+    IF s IS DISTINCT FROM '57014' THEN
         RAISE EXCEPTION 'test 3.5: expected sqlstate 57014, got %', s;
     END IF;
     PERFORM pg_background_detach_v2(h.pid, h.cookie);

--- a/expected/pg_background.out
+++ b/expected/pg_background.out
@@ -1239,7 +1239,7 @@ SELECT
   workers_canceled  >= 1  AS has_canceled,
   workers_active    >= 0  AS has_active
 FROM pg_background_stats_v2();
- has_launched | has_completed | has_failed | has_canceled | has_active
+ has_launched | has_completed | has_failed | has_canceled | has_active 
 --------------+---------------+------------+--------------+------------
  t            | t             | t          | t            | t
 (1 row)

--- a/expected/pg_background.out
+++ b/expected/pg_background.out
@@ -1078,17 +1078,168 @@ SELECT 'PASS' AS detach_semantic_verified;
 (1 row)
 
 -- -------------------------------------------------------------------------
--- Final stats check
+-- Error propagation SQLSTATE tests (v1.9 bugfix)
+--
+-- Pattern: launch_v2 -> wait_v2 -> error_info_v2 -> detach_v2
+-- Do NOT call result_v2 for error cases: it ereport(ERROR)s in launcher,
+-- which aborts the transaction and destroys error_info_v2 data.
+-- -------------------------------------------------------------------------
+-- Test 3.1: Division by zero — SQLSTATE 22012 (execute path)
+DO $$
+DECLARE
+    h pg_background_handle;
+    s text;
+BEGIN
+    h := pg_background_launch_v2('SELECT 1/0');
+    PERFORM pg_background_wait_v2(h.pid, h.cookie);
+    SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
+    IF s <> '22012' THEN
+        RAISE EXCEPTION 'test 3.1: expected sqlstate 22012, got %', s;
+    END IF;
+    PERFORM pg_background_detach_v2(h.pid, h.cookie);
+    RAISE NOTICE 'test 3.1 (22012 division_by_zero) OK';
+END$$;
+NOTICE:  test 3.1 (22012 division_by_zero) OK
+-- Test 3.2: RAISE EXCEPTION — SQLSTATE P0001 (execute path)
+-- Use a helper function instead of nested dollar-quoting to avoid psql parsing issues.
+CREATE OR REPLACE FUNCTION pgbg_test_raise_p0001() RETURNS void
+    LANGUAGE plpgsql AS 'BEGIN RAISE EXCEPTION ''custom error''; END';
+DO $$
+DECLARE
+    h pg_background_handle;
+    s text;
+BEGIN
+    h := pg_background_launch_v2('SELECT pgbg_test_raise_p0001()');
+    PERFORM pg_background_wait_v2(h.pid, h.cookie);
+    SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
+    IF s <> 'P0001' THEN
+        RAISE EXCEPTION 'test 3.2: expected sqlstate P0001, got %', s;
+    END IF;
+    PERFORM pg_background_detach_v2(h.pid, h.cookie);
+    RAISE NOTICE 'test 3.2 (P0001 raise_exception) OK';
+END$$;
+NOTICE:  test 3.2 (P0001 raise_exception) OK
+DROP FUNCTION pgbg_test_raise_p0001();
+-- Test 3.3: NOT NULL violation — SQLSTATE 23502 (execute path)
+-- Note: temp tables are NOT visible to background workers (separate backend).
+-- Use a regular table with a unique prefix.
+DROP TABLE IF EXISTS pgbg_test_nn_23502;
+NOTICE:  table "pgbg_test_nn_23502" does not exist, skipping
+CREATE TABLE pgbg_test_nn_23502(c int NOT NULL);
+DO $$
+DECLARE
+    h pg_background_handle;
+    s text;
+BEGIN
+    h := pg_background_launch_v2('INSERT INTO pgbg_test_nn_23502 VALUES (NULL)');
+    PERFORM pg_background_wait_v2(h.pid, h.cookie);
+    SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
+    IF s <> '23502' THEN
+        RAISE EXCEPTION 'test 3.3: expected sqlstate 23502, got %', s;
+    END IF;
+    PERFORM pg_background_detach_v2(h.pid, h.cookie);
+    RAISE NOTICE 'test 3.3 (23502 not_null_violation) OK';
+END$$;
+NOTICE:  test 3.3 (23502 not_null_violation) OK
+DROP TABLE pgbg_test_nn_23502;
+-- Test 3.4: Deferred FK violation — SQLSTATE 23503 (commit path)
+-- FK is INITIALLY DEFERRED, so INSERT succeeds but COMMIT fails.
+-- The error fires in the commit-wrapper PG_CATCH (Phase 2 path).
+DROP TABLE IF EXISTS pgbg_test_fk_child_23503;
+NOTICE:  table "pgbg_test_fk_child_23503" does not exist, skipping
+DROP TABLE IF EXISTS pgbg_test_fk_parent_23503;
+NOTICE:  table "pgbg_test_fk_parent_23503" does not exist, skipping
+CREATE TABLE pgbg_test_fk_parent_23503(id int PRIMARY KEY);
+CREATE TABLE pgbg_test_fk_child_23503(
+    id int PRIMARY KEY,
+    parent_id int,
+    CONSTRAINT fk_23503_parent
+        FOREIGN KEY (parent_id) REFERENCES pgbg_test_fk_parent_23503(id)
+        DEFERRABLE INITIALLY DEFERRED
+);
+DO $$
+DECLARE
+    h pg_background_handle;
+    s text;
+BEGIN
+    -- Worker runs INSERT in its own auto-transaction.
+    -- INITIALLY DEFERRED FK fires at CommitTransactionCommand (commit-wrapper PG_CATCH).
+    -- Do NOT pass BEGIN/COMMIT: worker already runs in its own transaction.
+    h := pg_background_launch_v2(
+        'INSERT INTO pgbg_test_fk_child_23503 VALUES (1, 999)'
+    );
+    PERFORM pg_background_wait_v2(h.pid, h.cookie);
+    SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
+    IF s <> '23503' THEN
+        RAISE EXCEPTION 'test 3.4: expected sqlstate 23503, got %', s;
+    END IF;
+    PERFORM pg_background_detach_v2(h.pid, h.cookie);
+    RAISE NOTICE 'test 3.4 (23503 foreign_key_violation deferred) OK';
+END$$;
+NOTICE:  test 3.4 (23503 foreign_key_violation deferred) OK
+DROP TABLE pgbg_test_fk_child_23503;
+DROP TABLE pgbg_test_fk_parent_23503;
+-- Test 3.5: Cancel — SQLSTATE 57014 (execute path, query_canceled)
+-- Uses pg_sleep(30) to ensure worker is truly sleeping before cancel.
+-- Positive sync via pg_stat_activity: cancel is only sent after the worker
+-- is confirmed to be actively executing pg_sleep. Without this sync, cancel
+-- could land before SPI_execute starts (early-failure path) and the
+-- launcher would see 08006 instead of 57014.
+DO $$
+DECLARE
+    h     pg_background_handle;
+    w_pid int4;
+    s     text;
+    done  boolean;
+    cnt   int;
+BEGIN
+    h := pg_background_launch_v2('SELECT pg_sleep(30)');
+    w_pid := h.pid;
+    /* Positive sync: let the worker fork and reach SPI_execute, then
+       confirm it is actively running via pg_stat_activity.  An initial
+       sleep gives the OS scheduler time to start the child process;
+       afterwards we poll at 100 ms intervals for up to ~5 s total. */
+    PERFORM pg_sleep(0.5);
+    FOR i IN 1..50 LOOP
+        SELECT count(*) INTO cnt
+          FROM pg_stat_activity
+         WHERE pid = w_pid
+           AND state = 'active';
+        EXIT WHEN cnt > 0;
+        PERFORM pg_sleep(0.1);
+    END LOOP;
+    IF cnt = 0 THEN
+        RAISE EXCEPTION
+            'test 3.5: worker not active within 5.5s — test not valid';
+    END IF;
+    /* Worker is past pq_redirect_to_shm_mq and executing SQL; cancel
+       will be caught by the execute-phase PG_CATCH and produce 57014. */
+    PERFORM pg_background_cancel_v2_grace(h.pid, h.cookie, 100);
+    -- Wait for worker to stop after cancel (should be fast)
+    done := pg_background_wait_v2_timeout(h.pid, h.cookie, 5000);
+    IF NOT done THEN
+        RAISE EXCEPTION 'test 3.5: worker did not stop within 5s after cancel';
+    END IF;
+    SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
+    IF s <> '57014' THEN
+        RAISE EXCEPTION 'test 3.5: expected sqlstate 57014, got %', s;
+    END IF;
+    PERFORM pg_background_detach_v2(h.pid, h.cookie);
+    RAISE NOTICE 'test 3.5 (57014 query_canceled) OK';
+END$$;
+NOTICE:  test 3.5 (57014 query_canceled) OK
+-- -------------------------------------------------------------------------
+-- Final stats check (defensive form: >= N instead of hard-coded counts)
+-- This avoids brittleness when test count changes between phases.
 -- -------------------------------------------------------------------------
 SELECT
-  workers_launched AS total_launched,
-  workers_completed AS total_completed,
-  workers_failed AS total_failed,
-  workers_canceled AS total_canceled,
-  workers_active AS currently_active
+  workers_launched > 0   AS has_launched,
+  workers_failed >= 5    AS has_failed,
+  workers_canceled >= 1  AS has_canceled,
+  workers_active >= 0    AS has_active
 FROM pg_background_stats_v2();
- total_launched | total_completed | total_failed | total_canceled | currently_active 
-----------------+-----------------+--------------+----------------+------------------
-             26 |              17 |            1 |              8 |                0
+ has_launched | has_failed | has_canceled | has_active 
+--------------+------------+--------------+------------
+ t            | t          | t            | t
 (1 row)
 

--- a/expected/pg_background.out
+++ b/expected/pg_background.out
@@ -1233,13 +1233,14 @@ NOTICE:  test 3.5 (57014 query_canceled) OK
 -- This avoids brittleness when test count changes between phases.
 -- -------------------------------------------------------------------------
 SELECT
-  workers_launched > 0   AS has_launched,
-  workers_failed >= 5    AS has_failed,
-  workers_canceled >= 1  AS has_canceled,
-  workers_active >= 0    AS has_active
+  workers_launched   > 0  AS has_launched,
+  workers_completed  > 0  AS has_completed,
+  workers_failed    >= 5  AS has_failed,
+  workers_canceled  >= 1  AS has_canceled,
+  workers_active    >= 0  AS has_active
 FROM pg_background_stats_v2();
- has_launched | has_failed | has_canceled | has_active 
---------------+------------+--------------+------------
- t            | t          | t            | t
+ has_launched | has_completed | has_failed | has_canceled | has_active
+--------------+---------------+------------+--------------+------------
+ t            | t             | t          | t            | t
 (1 row)
 

--- a/expected/pg_background.out
+++ b/expected/pg_background.out
@@ -1198,9 +1198,9 @@ BEGIN
     /* Positive sync: let the worker fork and reach SPI_execute, then
        confirm it is actively running via pg_stat_activity.  An initial
        sleep gives the OS scheduler time to start the child process;
-       afterwards we poll at 100 ms intervals for up to ~5 s total. */
-    PERFORM pg_sleep(0.5);
-    FOR i IN 1..50 LOOP
+       afterwards we poll at 100 ms intervals for up to ~5.5 s total. */
+    PERFORM pg_sleep(0.1);
+    FOR i IN 1..55 LOOP
         SELECT count(*) INTO cnt
           FROM pg_stat_activity
          WHERE pid = w_pid
@@ -1210,7 +1210,7 @@ BEGIN
     END LOOP;
     IF cnt = 0 THEN
         RAISE EXCEPTION
-            'test 3.5: worker not active within 5.5s — test not valid';
+            'test 3.5: worker not active within 5.6s — test not valid';
     END IF;
     /* Worker is past pq_redirect_to_shm_mq and executing SQL; cancel
        will be caught by the execute-phase PG_CATCH and produce 57014. */

--- a/expected/pg_background_1.out
+++ b/expected/pg_background_1.out
@@ -108,7 +108,7 @@ SELECT pg_background_detach(
  
 (1 row)
 
-SELECT pg_sleep(0.2);
+SELECT pg_sleep(1.0);
  pg_sleep 
 ----------
  
@@ -130,7 +130,7 @@ BEGIN
   PERFORM pg_background_detach_v2(h.pid, h.cookie);
 END;
 $$;
-SELECT pg_sleep(0.2);
+SELECT pg_sleep(1.0);
  pg_sleep 
 ----------
  

--- a/expected/pg_background_1.out
+++ b/expected/pg_background_1.out
@@ -1239,7 +1239,7 @@ SELECT
   workers_canceled  >= 1  AS has_canceled,
   workers_active    >= 0  AS has_active
 FROM pg_background_stats_v2();
- has_launched | has_completed | has_failed | has_canceled | has_active
+ has_launched | has_completed | has_failed | has_canceled | has_active 
 --------------+---------------+------------+--------------+------------
  t            | t             | t          | t            | t
 (1 row)

--- a/expected/pg_background_1.out
+++ b/expected/pg_background_1.out
@@ -1233,13 +1233,14 @@ NOTICE:  test 3.5 (57014 query_canceled) OK
 -- This avoids brittleness when test count changes between phases.
 -- -------------------------------------------------------------------------
 SELECT
-  workers_launched > 0   AS has_launched,
-  workers_failed >= 5    AS has_failed,
-  workers_canceled >= 1  AS has_canceled,
-  workers_active >= 0    AS has_active
+  workers_launched   > 0  AS has_launched,
+  workers_completed  > 0  AS has_completed,
+  workers_failed    >= 5  AS has_failed,
+  workers_canceled  >= 1  AS has_canceled,
+  workers_active    >= 0  AS has_active
 FROM pg_background_stats_v2();
- has_launched | has_failed | has_canceled | has_active 
---------------+------------+--------------+------------
- t            | t          | t            | t
+ has_launched | has_completed | has_failed | has_canceled | has_active
+--------------+---------------+------------+--------------+------------
+ t            | t             | t          | t            | t
 (1 row)
 

--- a/expected/pg_background_1.out
+++ b/expected/pg_background_1.out
@@ -622,16 +622,16 @@ SELECT pg_background_wait_v2(:slbl_pid, :slbl_cookie);
 (1 row)
 
 SELECT count(*) AS submit_label_count FROM t_submit_label;
- submit_label_count 
+ submit_label_count
 --------------------
                   1
 (1 row)
 
 -- Cleanup: explicitly detach to avoid affecting later batch tests
 SELECT pg_background_detach_v2(:slbl_pid, :slbl_cookie);
- pg_background_detach_v2 
+ pg_background_detach_v2
 -------------------------
- 
+
 (1 row)
 
 -- -------------------------------------------------------------------------
@@ -742,7 +742,7 @@ SELECT pg_background_wait_v2(:b2_pid, :b2_cookie);
 
 -- Detach all at once
 SELECT pg_background_detach_all_v2() AS batch_detach_count;
- batch_detach_count 
+ batch_detach_count
 --------------------
                   2
 (1 row)
@@ -1093,7 +1093,7 @@ BEGIN
     h := pg_background_launch_v2('SELECT 1/0');
     PERFORM pg_background_wait_v2(h.pid, h.cookie);
     SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
-    IF s <> '22012' THEN
+    IF s IS DISTINCT FROM '22012' THEN
         RAISE EXCEPTION 'test 3.1: expected sqlstate 22012, got %', s;
     END IF;
     PERFORM pg_background_detach_v2(h.pid, h.cookie);
@@ -1112,7 +1112,7 @@ BEGIN
     h := pg_background_launch_v2('SELECT pgbg_test_raise_p0001()');
     PERFORM pg_background_wait_v2(h.pid, h.cookie);
     SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
-    IF s <> 'P0001' THEN
+    IF s IS DISTINCT FROM 'P0001' THEN
         RAISE EXCEPTION 'test 3.2: expected sqlstate P0001, got %', s;
     END IF;
     PERFORM pg_background_detach_v2(h.pid, h.cookie);
@@ -1134,7 +1134,7 @@ BEGIN
     h := pg_background_launch_v2('INSERT INTO pgbg_test_nn_23502 VALUES (NULL)');
     PERFORM pg_background_wait_v2(h.pid, h.cookie);
     SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
-    IF s <> '23502' THEN
+    IF s IS DISTINCT FROM '23502' THEN
         RAISE EXCEPTION 'test 3.3: expected sqlstate 23502, got %', s;
     END IF;
     PERFORM pg_background_detach_v2(h.pid, h.cookie);
@@ -1170,7 +1170,7 @@ BEGIN
     );
     PERFORM pg_background_wait_v2(h.pid, h.cookie);
     SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
-    IF s <> '23503' THEN
+    IF s IS DISTINCT FROM '23503' THEN
         RAISE EXCEPTION 'test 3.4: expected sqlstate 23503, got %', s;
     END IF;
     PERFORM pg_background_detach_v2(h.pid, h.cookie);
@@ -1221,7 +1221,7 @@ BEGIN
         RAISE EXCEPTION 'test 3.5: worker did not stop within 5s after cancel';
     END IF;
     SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
-    IF s <> '57014' THEN
+    IF s IS DISTINCT FROM '57014' THEN
         RAISE EXCEPTION 'test 3.5: expected sqlstate 57014, got %', s;
     END IF;
     PERFORM pg_background_detach_v2(h.pid, h.cookie);

--- a/expected/pg_background_1.out
+++ b/expected/pg_background_1.out
@@ -622,16 +622,16 @@ SELECT pg_background_wait_v2(:slbl_pid, :slbl_cookie);
 (1 row)
 
 SELECT count(*) AS submit_label_count FROM t_submit_label;
- submit_label_count
+ submit_label_count 
 --------------------
                   1
 (1 row)
 
 -- Cleanup: explicitly detach to avoid affecting later batch tests
 SELECT pg_background_detach_v2(:slbl_pid, :slbl_cookie);
- pg_background_detach_v2
+ pg_background_detach_v2 
 -------------------------
-
+ 
 (1 row)
 
 -- -------------------------------------------------------------------------
@@ -742,7 +742,7 @@ SELECT pg_background_wait_v2(:b2_pid, :b2_cookie);
 
 -- Detach all at once
 SELECT pg_background_detach_all_v2() AS batch_detach_count;
- batch_detach_count
+ batch_detach_count 
 --------------------
                   2
 (1 row)
@@ -1078,17 +1078,168 @@ SELECT 'PASS' AS detach_semantic_verified;
 (1 row)
 
 -- -------------------------------------------------------------------------
--- Final stats check
+-- Error propagation SQLSTATE tests (v1.9 bugfix)
+--
+-- Pattern: launch_v2 -> wait_v2 -> error_info_v2 -> detach_v2
+-- Do NOT call result_v2 for error cases: it ereport(ERROR)s in launcher,
+-- which aborts the transaction and destroys error_info_v2 data.
+-- -------------------------------------------------------------------------
+-- Test 3.1: Division by zero — SQLSTATE 22012 (execute path)
+DO $$
+DECLARE
+    h pg_background_handle;
+    s text;
+BEGIN
+    h := pg_background_launch_v2('SELECT 1/0');
+    PERFORM pg_background_wait_v2(h.pid, h.cookie);
+    SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
+    IF s <> '22012' THEN
+        RAISE EXCEPTION 'test 3.1: expected sqlstate 22012, got %', s;
+    END IF;
+    PERFORM pg_background_detach_v2(h.pid, h.cookie);
+    RAISE NOTICE 'test 3.1 (22012 division_by_zero) OK';
+END$$;
+NOTICE:  test 3.1 (22012 division_by_zero) OK
+-- Test 3.2: RAISE EXCEPTION — SQLSTATE P0001 (execute path)
+-- Use a helper function instead of nested dollar-quoting to avoid psql parsing issues.
+CREATE OR REPLACE FUNCTION pgbg_test_raise_p0001() RETURNS void
+    LANGUAGE plpgsql AS 'BEGIN RAISE EXCEPTION ''custom error''; END';
+DO $$
+DECLARE
+    h pg_background_handle;
+    s text;
+BEGIN
+    h := pg_background_launch_v2('SELECT pgbg_test_raise_p0001()');
+    PERFORM pg_background_wait_v2(h.pid, h.cookie);
+    SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
+    IF s <> 'P0001' THEN
+        RAISE EXCEPTION 'test 3.2: expected sqlstate P0001, got %', s;
+    END IF;
+    PERFORM pg_background_detach_v2(h.pid, h.cookie);
+    RAISE NOTICE 'test 3.2 (P0001 raise_exception) OK';
+END$$;
+NOTICE:  test 3.2 (P0001 raise_exception) OK
+DROP FUNCTION pgbg_test_raise_p0001();
+-- Test 3.3: NOT NULL violation — SQLSTATE 23502 (execute path)
+-- Note: temp tables are NOT visible to background workers (separate backend).
+-- Use a regular table with a unique prefix.
+DROP TABLE IF EXISTS pgbg_test_nn_23502;
+NOTICE:  table "pgbg_test_nn_23502" does not exist, skipping
+CREATE TABLE pgbg_test_nn_23502(c int NOT NULL);
+DO $$
+DECLARE
+    h pg_background_handle;
+    s text;
+BEGIN
+    h := pg_background_launch_v2('INSERT INTO pgbg_test_nn_23502 VALUES (NULL)');
+    PERFORM pg_background_wait_v2(h.pid, h.cookie);
+    SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
+    IF s <> '23502' THEN
+        RAISE EXCEPTION 'test 3.3: expected sqlstate 23502, got %', s;
+    END IF;
+    PERFORM pg_background_detach_v2(h.pid, h.cookie);
+    RAISE NOTICE 'test 3.3 (23502 not_null_violation) OK';
+END$$;
+NOTICE:  test 3.3 (23502 not_null_violation) OK
+DROP TABLE pgbg_test_nn_23502;
+-- Test 3.4: Deferred FK violation — SQLSTATE 23503 (commit path)
+-- FK is INITIALLY DEFERRED, so INSERT succeeds but COMMIT fails.
+-- The error fires in the commit-wrapper PG_CATCH (Phase 2 path).
+DROP TABLE IF EXISTS pgbg_test_fk_child_23503;
+NOTICE:  table "pgbg_test_fk_child_23503" does not exist, skipping
+DROP TABLE IF EXISTS pgbg_test_fk_parent_23503;
+NOTICE:  table "pgbg_test_fk_parent_23503" does not exist, skipping
+CREATE TABLE pgbg_test_fk_parent_23503(id int PRIMARY KEY);
+CREATE TABLE pgbg_test_fk_child_23503(
+    id int PRIMARY KEY,
+    parent_id int,
+    CONSTRAINT fk_23503_parent
+        FOREIGN KEY (parent_id) REFERENCES pgbg_test_fk_parent_23503(id)
+        DEFERRABLE INITIALLY DEFERRED
+);
+DO $$
+DECLARE
+    h pg_background_handle;
+    s text;
+BEGIN
+    -- Worker runs INSERT in its own auto-transaction.
+    -- INITIALLY DEFERRED FK fires at CommitTransactionCommand (commit-wrapper PG_CATCH).
+    -- Do NOT pass BEGIN/COMMIT: worker already runs in its own transaction.
+    h := pg_background_launch_v2(
+        'INSERT INTO pgbg_test_fk_child_23503 VALUES (1, 999)'
+    );
+    PERFORM pg_background_wait_v2(h.pid, h.cookie);
+    SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
+    IF s <> '23503' THEN
+        RAISE EXCEPTION 'test 3.4: expected sqlstate 23503, got %', s;
+    END IF;
+    PERFORM pg_background_detach_v2(h.pid, h.cookie);
+    RAISE NOTICE 'test 3.4 (23503 foreign_key_violation deferred) OK';
+END$$;
+NOTICE:  test 3.4 (23503 foreign_key_violation deferred) OK
+DROP TABLE pgbg_test_fk_child_23503;
+DROP TABLE pgbg_test_fk_parent_23503;
+-- Test 3.5: Cancel — SQLSTATE 57014 (execute path, query_canceled)
+-- Uses pg_sleep(30) to ensure worker is truly sleeping before cancel.
+-- Positive sync via pg_stat_activity: cancel is only sent after the worker
+-- is confirmed to be actively executing pg_sleep. Without this sync, cancel
+-- could land before SPI_execute starts (early-failure path) and the
+-- launcher would see 08006 instead of 57014.
+DO $$
+DECLARE
+    h     pg_background_handle;
+    w_pid int4;
+    s     text;
+    done  boolean;
+    cnt   int;
+BEGIN
+    h := pg_background_launch_v2('SELECT pg_sleep(30)');
+    w_pid := h.pid;
+    /* Positive sync: let the worker fork and reach SPI_execute, then
+       confirm it is actively running via pg_stat_activity.  An initial
+       sleep gives the OS scheduler time to start the child process;
+       afterwards we poll at 100 ms intervals for up to ~5 s total. */
+    PERFORM pg_sleep(0.5);
+    FOR i IN 1..50 LOOP
+        SELECT count(*) INTO cnt
+          FROM pg_stat_activity
+         WHERE pid = w_pid
+           AND state = 'active';
+        EXIT WHEN cnt > 0;
+        PERFORM pg_sleep(0.1);
+    END LOOP;
+    IF cnt = 0 THEN
+        RAISE EXCEPTION
+            'test 3.5: worker not active within 5.5s — test not valid';
+    END IF;
+    /* Worker is past pq_redirect_to_shm_mq and executing SQL; cancel
+       will be caught by the execute-phase PG_CATCH and produce 57014. */
+    PERFORM pg_background_cancel_v2_grace(h.pid, h.cookie, 100);
+    -- Wait for worker to stop after cancel (should be fast)
+    done := pg_background_wait_v2_timeout(h.pid, h.cookie, 5000);
+    IF NOT done THEN
+        RAISE EXCEPTION 'test 3.5: worker did not stop within 5s after cancel';
+    END IF;
+    SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
+    IF s <> '57014' THEN
+        RAISE EXCEPTION 'test 3.5: expected sqlstate 57014, got %', s;
+    END IF;
+    PERFORM pg_background_detach_v2(h.pid, h.cookie);
+    RAISE NOTICE 'test 3.5 (57014 query_canceled) OK';
+END$$;
+NOTICE:  test 3.5 (57014 query_canceled) OK
+-- -------------------------------------------------------------------------
+-- Final stats check (defensive form: >= N instead of hard-coded counts)
+-- This avoids brittleness when test count changes between phases.
 -- -------------------------------------------------------------------------
 SELECT
-  workers_launched AS total_launched,
-  workers_completed AS total_completed,
-  workers_failed AS total_failed,
-  workers_canceled AS total_canceled,
-  workers_active AS currently_active
+  workers_launched > 0   AS has_launched,
+  workers_failed >= 5    AS has_failed,
+  workers_canceled >= 1  AS has_canceled,
+  workers_active >= 0    AS has_active
 FROM pg_background_stats_v2();
- total_launched | total_completed | total_failed | total_canceled | currently_active 
-----------------+-----------------+--------------+----------------+------------------
-             26 |              17 |            1 |              8 |                0
+ has_launched | has_failed | has_canceled | has_active 
+--------------+------------+--------------+------------
+ t            | t          | t            | t
 (1 row)
 

--- a/pg_background.c
+++ b/pg_background.c
@@ -2454,6 +2454,22 @@ pg_background_worker_main(Datum main_arg)
 
     pq_redirect_to_shm_mq(seg, responseq);
 
+    /*
+     * v1.9 Phase 2: Init-phase PG_TRY.
+     *
+     * Outer PG_TRY covers init-phase calls (BackgroundWorkerInitializeConnection,
+     * StartTransactionCommand, RestoreGUCState, SetUserIdAndSecContext) and the
+     * execute phase below. Commit is wrapped in a separate sequential PG_TRY
+     * after PG_END_TRY so that a single EmitErrorReport is produced per error
+     * (no overlap between init/execute and commit catches).
+     *
+     * PG_TRY starts AFTER pq_redirect_to_shm_mq() so EmitErrorReport can write
+     * the 'E' frame into the hijacked pqmq destination. Failures before redirect
+     * (dsm_attach, shm_toc_lookup) remain under the standard bgworker handler
+     * and degrade the launcher to 08006 — documented acceptable limitation.
+     */
+    PG_TRY();
+    {
     BackgroundWorkerInitializeConnection(NameStr(fdata->database),
                                          NameStr(fdata->authenticated_user),
                                          BGWORKER_BYPASS_ALLOWCONN);
@@ -2597,6 +2613,32 @@ pg_background_worker_main(Datum main_arg)
         FreeErrorData(edata);
 
         /*
+         * v1.9: Propagate real SQLSTATE to the launcher via shm_mq.
+         *
+         * EmitErrorReport() writes the 'E' error frame to the hijacked
+         * destination set up by pq_redirect_to_shm_mq(), so the launcher
+         * sees the actual sqlerrcode (e.g. 22012 / P0001 / 23502) instead
+         * of degrading to ERRCODE_CONNECTION_FAILURE ("lost connection to
+         * worker process").
+         *
+         * Wrap in a nested PG_TRY: if pq_sendstring hits OOM inside
+         * EmitErrorReport it would ereport(ERROR) and recurse into this
+         * very PG_CATCH frame (→ backend crash). Mirror PostgreSQL core's
+         * ParallelWorkerMain() swallow pattern — on inner failure just
+         * FlushErrorState() and continue; the DSM error fields already
+         * carry the SQLSTATE so the launcher still gets useful info.
+         */
+        PG_TRY();
+        {
+            EmitErrorReport();
+        }
+        PG_CATCH();
+        {
+            FlushErrorState();
+        }
+        PG_END_TRY();
+
+        /*
          * Do NOT use PG_RE_THROW() here - that causes the worker to exit
          * abnormally, which PostgreSQL interprets as a crash and terminates
          * all connections. Instead, clean up and exit gracefully.
@@ -2608,6 +2650,17 @@ pg_background_worker_main(Datum main_arg)
             AbortCurrentTransaction();
 
         /*
+         * Mirror happy-path shutdown: mark session idle, send 'Z' so the
+         * launcher's result state machine flips state->complete = true,
+         * then flush any bytes still buffered in pqmq before proc_exit
+         * detaches the shm_mq (otherwise trailing 'E'/'Z' frames would be
+         * dropped together with the queue).
+         */
+        pgstat_report_activity(STATE_IDLE, NULL);
+        ReadyForQuery(DestRemote);
+        pq_flush();
+
+        /*
          * Exit with code 1 to indicate failure (not 0 for success).
          * This is a clean exit, not a crash, so PostgreSQL won't panic.
          */
@@ -2616,12 +2669,159 @@ pg_background_worker_main(Datum main_arg)
     PG_END_TRY();
 
     disable_timeout(STATEMENT_TIMEOUT, false);
-    CommitTransactionCommand();
+    }
+    PG_CATCH();
+    {
+        ErrorData *edata;
 
-    pgstat_report_activity(STATE_IDLE, sql);
-    pgstat_report_stat(true);
+        /*
+         * v1.9 Phase 2: Init-phase PG_CATCH.
+         *
+         * Catches failures from BackgroundWorkerInitializeConnection,
+         * StartTransactionCommand, RestoreGUCState, SetUserIdAndSecContext,
+         * and the execute-phase PG_END_TRY fall-through (disable_timeout).
+         * Execute-phase SQL errors are caught by the inner execute PG_CATCH
+         * above (which calls proc_exit(1) directly), so this handler only
+         * fires on init-phase errors.
+         */
+        HOLD_INTERRUPTS();
 
-    ReadyForQuery(DestRemote);
+        /*
+         * Switch out of ErrorContext before CopyErrorData (Assert prevents
+         * use-after-free when ErrorContext is reset on next error).
+         */
+        MemoryContextSwitchTo(TopMemoryContext);
+        edata = CopyErrorData();
+
+        /* Clear stale result metadata — no rows produced on init failure. */
+        fdata->result_row_count = 0;
+        fdata->command_tag[0] = '\0';
+
+        if (edata->message != NULL)
+            strlcpy(fdata->error_message, edata->message, sizeof(fdata->error_message));
+        if (edata->detail != NULL)
+            strlcpy(fdata->error_detail, edata->detail, sizeof(fdata->error_detail));
+        if (edata->hint != NULL)
+            strlcpy(fdata->error_hint, edata->hint, sizeof(fdata->error_hint));
+        if (edata->context != NULL)
+            strlcpy(fdata->error_context, edata->context, sizeof(fdata->error_context));
+
+        /* Publish: other fields first, then sqlstate as presence flag. */
+        pg_write_barrier();
+        snprintf(fdata->error_sqlstate, sizeof(fdata->error_sqlstate), "%s",
+                 unpack_sql_state(edata->sqlerrcode));
+
+        FreeErrorData(edata);
+
+        /*
+         * Nested PG_TRY around EmitErrorReport: pq_sendstring OOM inside
+         * EmitErrorReport could ereport(ERROR) and recurse into this frame.
+         * Mirror ParallelWorkerMain swallow pattern — FlushErrorState only.
+         */
+        PG_TRY();
+        {
+            EmitErrorReport();
+        }
+        PG_CATCH();
+        {
+            FlushErrorState();
+        }
+        PG_END_TRY();
+
+        FlushErrorState();
+
+        /* Guard against double-abort after AbortCurrentTransaction already ran. */
+        if (IsTransactionState())
+            AbortCurrentTransaction();
+
+        pgstat_report_activity(STATE_IDLE, NULL);
+        ReadyForQuery(DestRemote);
+        pq_flush();
+
+        RESUME_INTERRUPTS();
+
+        proc_exit(1);
+    }
+    PG_END_TRY();
+
+    /*
+     * v1.9 Phase 2: Commit-wrapper PG_TRY (SEQUENTIAL, NOT nested).
+     *
+     * CommitTransactionCommand() fires deferred constraint triggers and
+     * AFTER-triggers, so commit-time errors (23503 deferred FK, 57014 cancel,
+     * 23505 deferred unique) surface here. Wrapping commit in its own PG_TRY
+     * keeps "exactly one EmitErrorReport per error" invariant — init-phase
+     * PG_CATCH above already ran PG_END_TRY, so a commit failure here does
+     * not double-report via init catch.
+     */
+    PG_TRY();
+    {
+        CommitTransactionCommand();
+
+        pgstat_report_activity(STATE_IDLE, sql);
+        pgstat_report_stat(true);
+
+        ReadyForQuery(DestRemote);
+    }
+    PG_CATCH();
+    {
+        /*
+         * v1.9 Phase 2: Commit-phase PG_CATCH. Same full Phase 1 pattern as
+         * init-phase catch above.
+         */
+        ErrorData *edata;
+
+        HOLD_INTERRUPTS();
+
+        MemoryContextSwitchTo(TopMemoryContext);
+        edata = CopyErrorData();
+
+        fdata->result_row_count = 0;
+        fdata->command_tag[0] = '\0';
+
+        if (edata->message != NULL)
+            strlcpy(fdata->error_message, edata->message, sizeof(fdata->error_message));
+        if (edata->detail != NULL)
+            strlcpy(fdata->error_detail, edata->detail, sizeof(fdata->error_detail));
+        if (edata->hint != NULL)
+            strlcpy(fdata->error_hint, edata->hint, sizeof(fdata->error_hint));
+        if (edata->context != NULL)
+            strlcpy(fdata->error_context, edata->context, sizeof(fdata->error_context));
+
+        pg_write_barrier();
+        snprintf(fdata->error_sqlstate, sizeof(fdata->error_sqlstate), "%s",
+                 unpack_sql_state(edata->sqlerrcode));
+
+        FreeErrorData(edata);
+
+        PG_TRY();
+        {
+            EmitErrorReport();
+        }
+        PG_CATCH();
+        {
+            FlushErrorState();
+        }
+        PG_END_TRY();
+
+        FlushErrorState();
+
+        /*
+         * CommitTransactionCommand may have partially torn down the xact
+         * before erroring. Guard the abort with IsTransactionState().
+         */
+        if (IsTransactionState())
+            AbortCurrentTransaction();
+
+        pgstat_report_activity(STATE_IDLE, NULL);
+        ReadyForQuery(DestRemote);
+        pq_flush();
+
+        RESUME_INTERRUPTS();
+
+        proc_exit(1);
+    }
+    PG_END_TRY();
 
     /*
      * Explicit ResourceOwner cleanup on normal exit path.

--- a/pg_background.c
+++ b/pg_background.c
@@ -349,7 +349,6 @@ static HeapTuple form_result_tuple(pg_background_result_state *state,
 /* Worker execution */
 static void handle_sigterm(SIGNAL_ARGS);
 static void execute_sql_string(const char *sql, pg_background_fixed_data *fdata);
-static void pg_background_worker_error_exit(pg_background_fixed_data *fdata) pg_attribute_noreturn();
 static bool exists_binary_recv_fn(Oid type);
 
 /* Internal launcher (shared by v1 and v2 APIs) */
@@ -406,7 +405,6 @@ pgbg_portal_run_compat(Portal portal,
 }
 /* v2 API helpers */
 static uint64 pg_background_make_cookie(void);
-static inline long pgbg_timestamp_diff_ms(TimestampTz start, TimestampTz stop);
 static void pgbg_request_cancel(pg_background_worker_info *info);
 static void pgbg_send_cancel_signals(pg_background_worker_info *info, int32 grace_ms);
 static const char *pgbg_state_from_handle(pg_background_worker_info *info);

--- a/pg_background.c
+++ b/pg_background.c
@@ -2415,6 +2415,8 @@ pg_background_worker_error_exit(pg_background_fixed_data *fdata)
 {
     ErrorData  *edata;
 
+    Assert(fdata != NULL);  /* callers guarantee this; crash loudly if violated */
+
     HOLD_INTERRUPTS();
 
     /*
@@ -2443,10 +2445,9 @@ pg_background_worker_error_exit(pg_background_fixed_data *fdata)
      * readers before we set the publish flag (error_sqlstate).
      */
     pg_write_barrier();
-    snprintf(fdata->error_sqlstate, sizeof(fdata->error_sqlstate), "%s",
-             unpack_sql_state(edata->sqlerrcode));
-
-    FreeErrorData(edata);
+    /* unpack_sql_state() always returns 5 chars + NUL, fits in PGBG_ERROR_SQLSTATE_LEN */
+    strlcpy(fdata->error_sqlstate, unpack_sql_state(edata->sqlerrcode),
+            sizeof(fdata->error_sqlstate));
 
     /*
      * Emit the real 'E' frame over shm_mq so the launcher's result state
@@ -2461,10 +2462,19 @@ pg_background_worker_error_exit(pg_background_fixed_data *fdata)
     }
     PG_CATCH();
     {
-        FlushErrorState();
+        FlushErrorState();  /* flush any error raised by EmitErrorReport itself */
     }
     PG_END_TRY();
 
+    FreeErrorData(edata);
+
+    /*
+     * Two FlushErrorState calls are both required:
+     * - The PG_CATCH above flushed any secondary error raised by EmitErrorReport.
+     * - This call flushes the *original* worker error, which CopyErrorData() copied
+     *   but did not remove from the ErrorContext stack.  Without this, the caller's
+     *   PG_END_TRY would observe stale error state.
+     */
     FlushErrorState();
 
     if (IsTransactionState())
@@ -2650,10 +2660,9 @@ pg_background_worker_main(Datum main_arg)
     {
         /*
          * Init-phase error: BackgroundWorkerInitializeConnection,
-         * StartTransactionCommand, RestoreGUCState, SetUserIdAndSecContext,
-         * or disable_timeout after the inner execute phase.  Execute-phase
-         * SQL errors exit via proc_exit(1) inside the inner PG_CATCH above
-         * and never reach here.
+         * StartTransactionCommand, RestoreGUCState, or SetUserIdAndSecContext.
+         * Execute-phase SQL errors exit via proc_exit(1) inside the inner
+         * PG_CATCH above and never reach here.
          */
         pg_background_worker_error_exit(fdata);
     }

--- a/pg_background.c
+++ b/pg_background.c
@@ -2455,7 +2455,7 @@ pg_background_worker_main(Datum main_arg)
     pq_redirect_to_shm_mq(seg, responseq);
 
     /*
-     * v1.9 Phase 2: Init-phase PG_TRY.
+     * Init-phase PG_TRY.
      *
      * Outer PG_TRY covers init-phase calls (BackgroundWorkerInitializeConnection,
      * StartTransactionCommand, RestoreGUCState, SetUserIdAndSecContext) and the
@@ -2470,212 +2470,212 @@ pg_background_worker_main(Datum main_arg)
      */
     PG_TRY();
     {
-    BackgroundWorkerInitializeConnection(NameStr(fdata->database),
-                                         NameStr(fdata->authenticated_user),
-                                         BGWORKER_BYPASS_ALLOWCONN);
+        BackgroundWorkerInitializeConnection(NameStr(fdata->database),
+                                             NameStr(fdata->authenticated_user),
+                                             BGWORKER_BYPASS_ALLOWCONN);
 
-    if (fdata->database_id != MyDatabaseId ||
-        fdata->authenticated_user_id != GetAuthenticatedUserId())
-        ereport(ERROR,
-                (errmsg("user or database renamed during pg_background startup")));
+        if (fdata->database_id != MyDatabaseId ||
+            fdata->authenticated_user_id != GetAuthenticatedUserId())
+            ereport(ERROR,
+                    (errmsg("user or database renamed during pg_background startup")));
 
-    StartTransactionCommand();
-    RestoreGUCState(gucstate);
-    CommitTransactionCommand();
+        StartTransactionCommand();
+        RestoreGUCState(gucstate);
+        CommitTransactionCommand();
 
-    /* If cancel was requested before we began, exit quietly */
-    /*
-     * I5: Volatile access for cancel flag race protection
-     * 
-     * The cancel_requested field is shared memory accessed by:
-     * 1. Launcher session (writes via pgbg_request_cancel)
-     * 2. Worker process (reads here and potentially in signal handler)
-     * 
-     * Without volatile, compiler could cache the read and miss concurrent updates.
-     * While PostgreSQL's CHECK_FOR_INTERRUPTS() handles most cancellation via
-     * signals, this flag provides best-effort early exit before SQL execution.
-     * 
-     * NOTE: Full memory barrier semantics not required here - we only need to
-     * prevent compiler optimization. Signal handler will set InterruptPending
-     * which is already volatile in PostgreSQL core.
-     */
-    if (*(volatile uint32 *)&fdata->cancel_requested != 0)
-    {
+        /* If cancel was requested before we began, exit quietly */
         /*
-         * Explicitly delete the ResourceOwner before proc_exit to ensure
-         * clean resource cleanup. This prevents warnings about leaked
-         * resources in PostgreSQL debug builds.
+         * I5: Volatile access for cancel flag race protection
+         * 
+         * The cancel_requested field is shared memory accessed by:
+         * 1. Launcher session (writes via pgbg_request_cancel)
+         * 2. Worker process (reads here and potentially in signal handler)
+         * 
+         * Without volatile, compiler could cache the read and miss concurrent updates.
+         * While PostgreSQL's CHECK_FOR_INTERRUPTS() handles most cancellation via
+         * signals, this flag provides best-effort early exit before SQL execution.
+         * 
+         * NOTE: Full memory barrier semantics not required here - we only need to
+         * prevent compiler optimization. Signal handler will set InterruptPending
+         * which is already volatile in PostgreSQL core.
          */
-        ResourceOwnerDelete(CurrentResourceOwner);
-        CurrentResourceOwner = NULL;
-        proc_exit(0);
-    }
+        if (*(volatile uint32 *)&fdata->cancel_requested != 0)
+        {
+            /*
+             * Explicitly delete the ResourceOwner before proc_exit to ensure
+             * clean resource cleanup. This prevents warnings about leaked
+             * resources in PostgreSQL debug builds.
+             */
+            ResourceOwnerDelete(CurrentResourceOwner);
+            CurrentResourceOwner = NULL;
+            proc_exit(0);
+        }
 
-    SetCurrentStatementStartTimestamp();
-    debug_query_string = sql;
-    pgstat_report_activity(STATE_RUNNING, sql);
+        SetCurrentStatementStartTimestamp();
+        debug_query_string = sql;
+        pgstat_report_activity(STATE_RUNNING, sql);
 
-    StartTransactionCommand();
-
-    /*
-     * Apply worker timeout. Priority:
-     * 1. pg_background.worker_timeout if set (> 0)
-     * 2. session's statement_timeout if set (> 0)
-     * 3. no timeout
-     */
-    {
-        int effective_timeout = 0;
-
-        if (pgbg_worker_timeout > 0)
-            effective_timeout = pgbg_worker_timeout;
-        else if (StatementTimeout > 0)
-            effective_timeout = StatementTimeout;
-
-        if (effective_timeout > 0)
-            enable_timeout_after(STATEMENT_TIMEOUT, effective_timeout);
-        else
-            disable_timeout(STATEMENT_TIMEOUT, false);
-    }
-
-    SetUserIdAndSecContext(fdata->current_user_id, fdata->sec_context);
-
-    /*
-     * Execute with error capture for v1.9 structured errors.
-     *
-     * NOTE: Structured error capture only covers SQL execution errors.
-     * Early worker failures (DSM attach, TOC lookup, connection init) happen
-     * before this point and won't populate error_sqlstate/error_message.
-     * For those cases, error_info_v2() returns NULL and result_info_v2().has_error
-     * is false, but the worker still fails visibly (detected via BgwHandleStatus).
-     * This is acceptable since early failures are infrastructure errors, not SQL errors.
-     */
-    PG_TRY();
-    {
-        execute_sql_string(sql, fdata);
-    }
-    PG_CATCH();
-    {
-        ErrorData *edata;
+        StartTransactionCommand();
 
         /*
-         * v1.9: Capture structured error info before re-throwing.
+         * Apply worker timeout. Priority:
+         * 1. pg_background.worker_timeout if set (> 0)
+         * 2. session's statement_timeout if set (> 0)
+         * 3. no timeout
+         */
+        {
+            int effective_timeout = 0;
+
+            if (pgbg_worker_timeout > 0)
+                effective_timeout = pgbg_worker_timeout;
+            else if (StatementTimeout > 0)
+                effective_timeout = StatementTimeout;
+
+            if (effective_timeout > 0)
+                enable_timeout_after(STATEMENT_TIMEOUT, effective_timeout);
+            else
+                disable_timeout(STATEMENT_TIMEOUT, false);
+        }
+
+        SetUserIdAndSecContext(fdata->current_user_id, fdata->sec_context);
+
+        /*
+         * Execute with error capture for v1.9 structured errors.
          *
-         * IMPORTANT: Must switch out of ErrorContext before calling
-         * CopyErrorData(). PostgreSQL's CopyErrorData() allocates the copy
-         * in CurrentMemoryContext, and asserts that it's not ErrorContext
-         * (to prevent use-after-free when ErrorContext is reset on next error).
-         */
-        MemoryContextSwitchTo(TopMemoryContext);
-        edata = CopyErrorData();
-
-        /*
-         * Clear result metadata to avoid stale values from earlier successful
-         * statements in a multi-statement SQL string. On error, row_count and
-         * command_tag should not reflect partial success.
-         */
-        fdata->result_row_count = 0;
-        fdata->command_tag[0] = '\0';
-
-        /*
-         * Write error fields in safe order for concurrent readers.
-         * error_sqlstate is the presence flag checked by error_info_v2 and
-         * result_info_v2, so write it LAST after all other fields are populated.
-         * This ensures readers never see partial error data.
-         */
-
-        /* Store error message (truncate if needed) */
-        if (edata->message != NULL)
-            strlcpy(fdata->error_message, edata->message, sizeof(fdata->error_message));
-
-        /* Store detail if available */
-        if (edata->detail != NULL)
-            strlcpy(fdata->error_detail, edata->detail, sizeof(fdata->error_detail));
-
-        /* Store hint if available */
-        if (edata->hint != NULL)
-            strlcpy(fdata->error_hint, edata->hint, sizeof(fdata->error_hint));
-
-        /* Store context if available */
-        if (edata->context != NULL)
-            strlcpy(fdata->error_context, edata->context, sizeof(fdata->error_context));
-
-        /*
-         * Write barrier: ensure all fields above are visible before the
-         * presence flag. pg_write_barrier() is a compiler barrier that
-         * prevents reordering; on x86 stores are already ordered.
-         */
-        pg_write_barrier();
-
-        /* Store SQLSTATE LAST - this is the publish flag for readers */
-        snprintf(fdata->error_sqlstate, sizeof(fdata->error_sqlstate), "%s",
-                 unpack_sql_state(edata->sqlerrcode));
-
-        FreeErrorData(edata);
-
-        /*
-         * v1.9: Propagate real SQLSTATE to the launcher via shm_mq.
-         *
-         * EmitErrorReport() writes the 'E' error frame to the hijacked
-         * destination set up by pq_redirect_to_shm_mq(), so the launcher
-         * sees the actual sqlerrcode (e.g. 22012 / P0001 / 23502) instead
-         * of degrading to ERRCODE_CONNECTION_FAILURE ("lost connection to
-         * worker process").
-         *
-         * Wrap in a nested PG_TRY: if pq_sendstring hits OOM inside
-         * EmitErrorReport it would ereport(ERROR) and recurse into this
-         * very PG_CATCH frame (→ backend crash). Mirror PostgreSQL core's
-         * ParallelWorkerMain() swallow pattern — on inner failure just
-         * FlushErrorState() and continue; the DSM error fields already
-         * carry the SQLSTATE so the launcher still gets useful info.
+         * NOTE: Structured error capture only covers SQL execution errors.
+         * Early worker failures (DSM attach, TOC lookup, connection init) happen
+         * before this point and won't populate error_sqlstate/error_message.
+         * For those cases, error_info_v2() returns NULL and result_info_v2().has_error
+         * is false, but the worker still fails visibly (detected via BgwHandleStatus).
+         * This is acceptable since early failures are infrastructure errors, not SQL errors.
          */
         PG_TRY();
         {
-            EmitErrorReport();
+            execute_sql_string(sql, fdata);
         }
         PG_CATCH();
         {
+            ErrorData *edata;
+
+            /*
+             * v1.9: Capture structured error info before re-throwing.
+             *
+             * IMPORTANT: Must switch out of ErrorContext before calling
+             * CopyErrorData(). PostgreSQL's CopyErrorData() allocates the copy
+             * in CurrentMemoryContext, and asserts that it's not ErrorContext
+             * (to prevent use-after-free when ErrorContext is reset on next error).
+             */
+            MemoryContextSwitchTo(TopMemoryContext);
+            edata = CopyErrorData();
+
+            /*
+             * Clear result metadata to avoid stale values from earlier successful
+             * statements in a multi-statement SQL string. On error, row_count and
+             * command_tag should not reflect partial success.
+             */
+            fdata->result_row_count = 0;
+            fdata->command_tag[0] = '\0';
+
+            /*
+             * Write error fields in safe order for concurrent readers.
+             * error_sqlstate is the presence flag checked by error_info_v2 and
+             * result_info_v2, so write it LAST after all other fields are populated.
+             * This ensures readers never see partial error data.
+             */
+
+            /* Store error message (truncate if needed) */
+            if (edata->message != NULL)
+                strlcpy(fdata->error_message, edata->message, sizeof(fdata->error_message));
+
+            /* Store detail if available */
+            if (edata->detail != NULL)
+                strlcpy(fdata->error_detail, edata->detail, sizeof(fdata->error_detail));
+
+            /* Store hint if available */
+            if (edata->hint != NULL)
+                strlcpy(fdata->error_hint, edata->hint, sizeof(fdata->error_hint));
+
+            /* Store context if available */
+            if (edata->context != NULL)
+                strlcpy(fdata->error_context, edata->context, sizeof(fdata->error_context));
+
+            /*
+             * Write barrier: ensure all fields above are visible before the
+             * presence flag. pg_write_barrier() is a compiler barrier that
+             * prevents reordering; on x86 stores are already ordered.
+             */
+            pg_write_barrier();
+
+            /* Store SQLSTATE LAST - this is the publish flag for readers */
+            snprintf(fdata->error_sqlstate, sizeof(fdata->error_sqlstate), "%s",
+                     unpack_sql_state(edata->sqlerrcode));
+
+            FreeErrorData(edata);
+
+            /*
+             * v1.9: Propagate real SQLSTATE to the launcher via shm_mq.
+             *
+             * EmitErrorReport() writes the 'E' error frame to the hijacked
+             * destination set up by pq_redirect_to_shm_mq(), so the launcher
+             * sees the actual sqlerrcode (e.g. 22012 / P0001 / 23502) instead
+             * of degrading to ERRCODE_CONNECTION_FAILURE ("lost connection to
+             * worker process").
+             *
+             * Wrap in a nested PG_TRY: if pq_sendstring hits OOM inside
+             * EmitErrorReport it would ereport(ERROR) and recurse into this
+             * very PG_CATCH frame (→ backend crash). Mirror PostgreSQL core's
+             * ParallelWorkerMain() swallow pattern — on inner failure just
+             * FlushErrorState() and continue; the DSM error fields already
+             * carry the SQLSTATE so the launcher still gets useful info.
+             */
+            PG_TRY();
+            {
+                EmitErrorReport();
+            }
+            PG_CATCH();
+            {
+                FlushErrorState();
+            }
+            PG_END_TRY();
+
+            /*
+             * Do NOT use PG_RE_THROW() here - that causes the worker to exit
+             * abnormally, which PostgreSQL interprets as a crash and terminates
+             * all connections. Instead, clean up and exit gracefully.
+             */
             FlushErrorState();
+
+            /* Abort the transaction cleanly */
+            if (IsTransactionState())
+                AbortCurrentTransaction();
+
+            /*
+             * Mirror happy-path shutdown: mark session idle, send 'Z' so the
+             * launcher's result state machine flips state->complete = true,
+             * then flush any bytes still buffered in pqmq before proc_exit
+             * detaches the shm_mq (otherwise trailing 'E'/'Z' frames would be
+             * dropped together with the queue).
+             */
+            pgstat_report_activity(STATE_IDLE, NULL);
+            ReadyForQuery(DestRemote);
+            pq_flush();
+
+            /*
+             * Exit with code 1 to indicate failure (not 0 for success).
+             * This is a clean exit, not a crash, so PostgreSQL won't panic.
+             */
+            proc_exit(1);
         }
         PG_END_TRY();
 
-        /*
-         * Do NOT use PG_RE_THROW() here - that causes the worker to exit
-         * abnormally, which PostgreSQL interprets as a crash and terminates
-         * all connections. Instead, clean up and exit gracefully.
-         */
-        FlushErrorState();
-
-        /* Abort the transaction cleanly */
-        if (IsTransactionState())
-            AbortCurrentTransaction();
-
-        /*
-         * Mirror happy-path shutdown: mark session idle, send 'Z' so the
-         * launcher's result state machine flips state->complete = true,
-         * then flush any bytes still buffered in pqmq before proc_exit
-         * detaches the shm_mq (otherwise trailing 'E'/'Z' frames would be
-         * dropped together with the queue).
-         */
-        pgstat_report_activity(STATE_IDLE, NULL);
-        ReadyForQuery(DestRemote);
-        pq_flush();
-
-        /*
-         * Exit with code 1 to indicate failure (not 0 for success).
-         * This is a clean exit, not a crash, so PostgreSQL won't panic.
-         */
-        proc_exit(1);
-    }
-    PG_END_TRY();
-
-    disable_timeout(STATEMENT_TIMEOUT, false);
+        disable_timeout(STATEMENT_TIMEOUT, false);
     }
     PG_CATCH();
     {
         ErrorData *edata;
 
         /*
-         * v1.9 Phase 2: Init-phase PG_CATCH.
+         * Init-phase PG_CATCH.
          *
          * Catches failures from BackgroundWorkerInitializeConnection,
          * StartTransactionCommand, RestoreGUCState, SetUserIdAndSecContext,
@@ -2745,20 +2745,20 @@ pg_background_worker_main(Datum main_arg)
     PG_END_TRY();
 
     /*
-     * v1.9 Phase 2: Commit-wrapper PG_TRY (SEQUENTIAL, NOT nested).
+     * Commit-wrapper PG_TRY (SEQUENTIAL, NOT nested).
      *
      * CommitTransactionCommand() fires deferred constraint triggers and
      * AFTER-triggers, so commit-time errors (23503 deferred FK, 57014 cancel,
      * 23505 deferred unique) surface here. Wrapping commit in its own PG_TRY
-     * keeps "exactly one EmitErrorReport per error" invariant — init-phase
+     * keeps "exactly one EmitErrorReport per error" invariant — the init-phase
      * PG_CATCH above already ran PG_END_TRY, so a commit failure here does
-     * not double-report via init catch.
+     * not double-report via the init catch.
      */
     PG_TRY();
     {
         CommitTransactionCommand();
 
-        pgstat_report_activity(STATE_IDLE, sql);
+        pgstat_report_activity(STATE_IDLE, NULL);
         pgstat_report_stat(true);
 
         ReadyForQuery(DestRemote);
@@ -2766,8 +2766,8 @@ pg_background_worker_main(Datum main_arg)
     PG_CATCH();
     {
         /*
-         * v1.9 Phase 2: Commit-phase PG_CATCH. Same full Phase 1 pattern as
-         * init-phase catch above.
+         * Commit-phase PG_CATCH. Same full pattern as the execute-phase
+         * catch above.
          */
         ErrorData *edata;
 

--- a/pg_background.c
+++ b/pg_background.c
@@ -349,6 +349,7 @@ static HeapTuple form_result_tuple(pg_background_result_state *state,
 /* Worker execution */
 static void handle_sigterm(SIGNAL_ARGS);
 static void execute_sql_string(const char *sql, pg_background_fixed_data *fdata);
+static void pg_background_worker_error_exit(pg_background_fixed_data *fdata) pg_attribute_noreturn();
 static bool exists_binary_recv_fn(Oid type);
 
 /* Internal launcher (shared by v1 and v2 APIs) */
@@ -2397,6 +2398,91 @@ pg_background_error_callback(void *arg)
  */
 
 /*
+ * pg_background_worker_error_exit
+ *
+ * Common error-path exit shared by all three worker PG_CATCH handlers
+ * (execute-phase, init-phase, commit-phase).  Must be called from inside
+ * a PG_CATCH block with the current error still on the stack.
+ *
+ * Copies error data into the DSM fixed block for the launcher, emits the
+ * real 'E' frame over shm_mq (so the launcher sees the actual SQLSTATE
+ * instead of a synthesized 08006), sends ReadyForQuery, flushes the queue,
+ * and calls proc_exit(1).  Never returns.
+ *
+ * HOLD_INTERRUPTS/RESUME_INTERRUPTS bracket the body so that SIGTERM cannot
+ * interrupt pq_flush mid-frame, matching the ParallelWorkerMain pattern.
+ */
+static void
+pg_background_worker_error_exit(pg_background_fixed_data *fdata)
+{
+    ErrorData  *edata;
+
+    HOLD_INTERRUPTS();
+
+    /*
+     * Switch out of ErrorContext before CopyErrorData — PostgreSQL asserts
+     * CurrentMemoryContext != ErrorContext to prevent use-after-free when
+     * ErrorContext is reset on the next error.
+     */
+    MemoryContextSwitchTo(TopMemoryContext);
+    edata = CopyErrorData();
+
+    /* Clear result metadata: no rows produced when the worker errors out. */
+    fdata->result_row_count = 0;
+    fdata->command_tag[0] = '\0';
+
+    if (edata->message != NULL)
+        strlcpy(fdata->error_message, edata->message, sizeof(fdata->error_message));
+    if (edata->detail != NULL)
+        strlcpy(fdata->error_detail, edata->detail, sizeof(fdata->error_detail));
+    if (edata->hint != NULL)
+        strlcpy(fdata->error_hint, edata->hint, sizeof(fdata->error_hint));
+    if (edata->context != NULL)
+        strlcpy(fdata->error_context, edata->context, sizeof(fdata->error_context));
+
+    /*
+     * Write barrier: ensure all fields above are visible to concurrent
+     * readers before we set the publish flag (error_sqlstate).
+     */
+    pg_write_barrier();
+    snprintf(fdata->error_sqlstate, sizeof(fdata->error_sqlstate), "%s",
+             unpack_sql_state(edata->sqlerrcode));
+
+    FreeErrorData(edata);
+
+    /*
+     * Emit the real 'E' frame over shm_mq so the launcher's result state
+     * machine sees the actual SQLSTATE.  Nested PG_TRY guards against OOM
+     * inside pq_sendstring recursing into this same error path — mirror the
+     * ParallelWorkerMain swallow pattern: FlushErrorState and continue.
+     * DSM already carries the SQLSTATE so the launcher still gets useful info.
+     */
+    PG_TRY();
+    {
+        EmitErrorReport();
+    }
+    PG_CATCH();
+    {
+        FlushErrorState();
+    }
+    PG_END_TRY();
+
+    FlushErrorState();
+
+    if (IsTransactionState())
+        AbortCurrentTransaction();
+
+    /* Mark session idle, send 'Z' to flip state->complete, flush the queue. */
+    pgstat_report_activity(STATE_IDLE, NULL);
+    ReadyForQuery(DestRemote);
+    pq_flush();
+
+    RESUME_INTERRUPTS();
+
+    proc_exit(1);
+}
+
+/*
  * pg_background_worker_main
  *     Entry point for background worker process.
  *
@@ -2555,116 +2641,8 @@ pg_background_worker_main(Datum main_arg)
         }
         PG_CATCH();
         {
-            ErrorData *edata;
-
-            /*
-             * v1.9: Capture structured error info before re-throwing.
-             *
-             * IMPORTANT: Must switch out of ErrorContext before calling
-             * CopyErrorData(). PostgreSQL's CopyErrorData() allocates the copy
-             * in CurrentMemoryContext, and asserts that it's not ErrorContext
-             * (to prevent use-after-free when ErrorContext is reset on next error).
-             */
-            MemoryContextSwitchTo(TopMemoryContext);
-            edata = CopyErrorData();
-
-            /*
-             * Clear result metadata to avoid stale values from earlier successful
-             * statements in a multi-statement SQL string. On error, row_count and
-             * command_tag should not reflect partial success.
-             */
-            fdata->result_row_count = 0;
-            fdata->command_tag[0] = '\0';
-
-            /*
-             * Write error fields in safe order for concurrent readers.
-             * error_sqlstate is the presence flag checked by error_info_v2 and
-             * result_info_v2, so write it LAST after all other fields are populated.
-             * This ensures readers never see partial error data.
-             */
-
-            /* Store error message (truncate if needed) */
-            if (edata->message != NULL)
-                strlcpy(fdata->error_message, edata->message, sizeof(fdata->error_message));
-
-            /* Store detail if available */
-            if (edata->detail != NULL)
-                strlcpy(fdata->error_detail, edata->detail, sizeof(fdata->error_detail));
-
-            /* Store hint if available */
-            if (edata->hint != NULL)
-                strlcpy(fdata->error_hint, edata->hint, sizeof(fdata->error_hint));
-
-            /* Store context if available */
-            if (edata->context != NULL)
-                strlcpy(fdata->error_context, edata->context, sizeof(fdata->error_context));
-
-            /*
-             * Write barrier: ensure all fields above are visible before the
-             * presence flag. pg_write_barrier() is a compiler barrier that
-             * prevents reordering; on x86 stores are already ordered.
-             */
-            pg_write_barrier();
-
-            /* Store SQLSTATE LAST - this is the publish flag for readers */
-            snprintf(fdata->error_sqlstate, sizeof(fdata->error_sqlstate), "%s",
-                     unpack_sql_state(edata->sqlerrcode));
-
-            FreeErrorData(edata);
-
-            /*
-             * v1.9: Propagate real SQLSTATE to the launcher via shm_mq.
-             *
-             * EmitErrorReport() writes the 'E' error frame to the hijacked
-             * destination set up by pq_redirect_to_shm_mq(), so the launcher
-             * sees the actual sqlerrcode (e.g. 22012 / P0001 / 23502) instead
-             * of degrading to ERRCODE_CONNECTION_FAILURE ("lost connection to
-             * worker process").
-             *
-             * Wrap in a nested PG_TRY: if pq_sendstring hits OOM inside
-             * EmitErrorReport it would ereport(ERROR) and recurse into this
-             * very PG_CATCH frame (→ backend crash). Mirror PostgreSQL core's
-             * ParallelWorkerMain() swallow pattern — on inner failure just
-             * FlushErrorState() and continue; the DSM error fields already
-             * carry the SQLSTATE so the launcher still gets useful info.
-             */
-            PG_TRY();
-            {
-                EmitErrorReport();
-            }
-            PG_CATCH();
-            {
-                FlushErrorState();
-            }
-            PG_END_TRY();
-
-            /*
-             * Do NOT use PG_RE_THROW() here - that causes the worker to exit
-             * abnormally, which PostgreSQL interprets as a crash and terminates
-             * all connections. Instead, clean up and exit gracefully.
-             */
-            FlushErrorState();
-
-            /* Abort the transaction cleanly */
-            if (IsTransactionState())
-                AbortCurrentTransaction();
-
-            /*
-             * Mirror happy-path shutdown: mark session idle, send 'Z' so the
-             * launcher's result state machine flips state->complete = true,
-             * then flush any bytes still buffered in pqmq before proc_exit
-             * detaches the shm_mq (otherwise trailing 'E'/'Z' frames would be
-             * dropped together with the queue).
-             */
-            pgstat_report_activity(STATE_IDLE, NULL);
-            ReadyForQuery(DestRemote);
-            pq_flush();
-
-            /*
-             * Exit with code 1 to indicate failure (not 0 for success).
-             * This is a clean exit, not a crash, so PostgreSQL won't panic.
-             */
-            proc_exit(1);
+            /* SQL execution error — store in DSM, emit 'E' frame, exit. */
+            pg_background_worker_error_exit(fdata);
         }
         PG_END_TRY();
 
@@ -2672,75 +2650,14 @@ pg_background_worker_main(Datum main_arg)
     }
     PG_CATCH();
     {
-        ErrorData *edata;
-
         /*
-         * Init-phase PG_CATCH.
-         *
-         * Catches failures from BackgroundWorkerInitializeConnection,
+         * Init-phase error: BackgroundWorkerInitializeConnection,
          * StartTransactionCommand, RestoreGUCState, SetUserIdAndSecContext,
-         * and the execute-phase PG_END_TRY fall-through (disable_timeout).
-         * Execute-phase SQL errors are caught by the inner execute PG_CATCH
-         * above (which calls proc_exit(1) directly), so this handler only
-         * fires on init-phase errors.
+         * or disable_timeout after the inner execute phase.  Execute-phase
+         * SQL errors exit via proc_exit(1) inside the inner PG_CATCH above
+         * and never reach here.
          */
-        HOLD_INTERRUPTS();
-
-        /*
-         * Switch out of ErrorContext before CopyErrorData (Assert prevents
-         * use-after-free when ErrorContext is reset on next error).
-         */
-        MemoryContextSwitchTo(TopMemoryContext);
-        edata = CopyErrorData();
-
-        /* Clear stale result metadata — no rows produced on init failure. */
-        fdata->result_row_count = 0;
-        fdata->command_tag[0] = '\0';
-
-        if (edata->message != NULL)
-            strlcpy(fdata->error_message, edata->message, sizeof(fdata->error_message));
-        if (edata->detail != NULL)
-            strlcpy(fdata->error_detail, edata->detail, sizeof(fdata->error_detail));
-        if (edata->hint != NULL)
-            strlcpy(fdata->error_hint, edata->hint, sizeof(fdata->error_hint));
-        if (edata->context != NULL)
-            strlcpy(fdata->error_context, edata->context, sizeof(fdata->error_context));
-
-        /* Publish: other fields first, then sqlstate as presence flag. */
-        pg_write_barrier();
-        snprintf(fdata->error_sqlstate, sizeof(fdata->error_sqlstate), "%s",
-                 unpack_sql_state(edata->sqlerrcode));
-
-        FreeErrorData(edata);
-
-        /*
-         * Nested PG_TRY around EmitErrorReport: pq_sendstring OOM inside
-         * EmitErrorReport could ereport(ERROR) and recurse into this frame.
-         * Mirror ParallelWorkerMain swallow pattern — FlushErrorState only.
-         */
-        PG_TRY();
-        {
-            EmitErrorReport();
-        }
-        PG_CATCH();
-        {
-            FlushErrorState();
-        }
-        PG_END_TRY();
-
-        FlushErrorState();
-
-        /* Guard against double-abort after AbortCurrentTransaction already ran. */
-        if (IsTransactionState())
-            AbortCurrentTransaction();
-
-        pgstat_report_activity(STATE_IDLE, NULL);
-        ReadyForQuery(DestRemote);
-        pq_flush();
-
-        RESUME_INTERRUPTS();
-
-        proc_exit(1);
+        pg_background_worker_error_exit(fdata);
     }
     PG_END_TRY();
 
@@ -2762,64 +2679,15 @@ pg_background_worker_main(Datum main_arg)
         pgstat_report_stat(true);
 
         ReadyForQuery(DestRemote);
+        pq_flush();
     }
     PG_CATCH();
     {
         /*
-         * Commit-phase PG_CATCH. Same full pattern as the execute-phase
-         * catch above.
+         * Commit-phase error: deferred constraints, AFTER triggers, or
+         * statement cancel during CommitTransactionCommand.
          */
-        ErrorData *edata;
-
-        HOLD_INTERRUPTS();
-
-        MemoryContextSwitchTo(TopMemoryContext);
-        edata = CopyErrorData();
-
-        fdata->result_row_count = 0;
-        fdata->command_tag[0] = '\0';
-
-        if (edata->message != NULL)
-            strlcpy(fdata->error_message, edata->message, sizeof(fdata->error_message));
-        if (edata->detail != NULL)
-            strlcpy(fdata->error_detail, edata->detail, sizeof(fdata->error_detail));
-        if (edata->hint != NULL)
-            strlcpy(fdata->error_hint, edata->hint, sizeof(fdata->error_hint));
-        if (edata->context != NULL)
-            strlcpy(fdata->error_context, edata->context, sizeof(fdata->error_context));
-
-        pg_write_barrier();
-        snprintf(fdata->error_sqlstate, sizeof(fdata->error_sqlstate), "%s",
-                 unpack_sql_state(edata->sqlerrcode));
-
-        FreeErrorData(edata);
-
-        PG_TRY();
-        {
-            EmitErrorReport();
-        }
-        PG_CATCH();
-        {
-            FlushErrorState();
-        }
-        PG_END_TRY();
-
-        FlushErrorState();
-
-        /*
-         * CommitTransactionCommand may have partially torn down the xact
-         * before erroring. Guard the abort with IsTransactionState().
-         */
-        if (IsTransactionState())
-            AbortCurrentTransaction();
-
-        pgstat_report_activity(STATE_IDLE, NULL);
-        ReadyForQuery(DestRemote);
-        pq_flush();
-
-        RESUME_INTERRUPTS();
-
-        proc_exit(1);
+        pg_background_worker_error_exit(fdata);
     }
     PG_END_TRY();
 

--- a/sql/pg_background.sql
+++ b/sql/pg_background.sql
@@ -861,9 +861,9 @@ BEGIN
     /* Positive sync: let the worker fork and reach SPI_execute, then
        confirm it is actively running via pg_stat_activity.  An initial
        sleep gives the OS scheduler time to start the child process;
-       afterwards we poll at 100 ms intervals for up to ~5 s total. */
-    PERFORM pg_sleep(0.5);
-    FOR i IN 1..50 LOOP
+       afterwards we poll at 100 ms intervals for up to ~5.5 s total. */
+    PERFORM pg_sleep(0.1);
+    FOR i IN 1..55 LOOP
         SELECT count(*) INTO cnt
           FROM pg_stat_activity
          WHERE pid = w_pid
@@ -873,7 +873,7 @@ BEGIN
     END LOOP;
     IF cnt = 0 THEN
         RAISE EXCEPTION
-            'test 3.5: worker not active within 5.5s — test not valid';
+            'test 3.5: worker not active within 5.6s — test not valid';
     END IF;
     /* Worker is past pq_redirect_to_shm_mq and executing SQL; cancel
        will be caught by the execute-phase PG_CATCH and produce 57014. */

--- a/sql/pg_background.sql
+++ b/sql/pg_background.sql
@@ -65,7 +65,7 @@ SELECT pg_background_detach(
   pg_background_launch('INSERT INTO t_detach_v1 SELECT 1', 65536)
 );
 
-SELECT pg_sleep(0.2);
+SELECT pg_sleep(1.0);
 SELECT count(*) FROM t_detach_v1;
 
 DROP TABLE IF EXISTS t_detach_v2;
@@ -79,7 +79,7 @@ BEGIN
 END;
 $$;
 
-SELECT pg_sleep(0.2);
+SELECT pg_sleep(1.0);
 SELECT count(*) FROM t_detach_v2;
 
 -- -------------------------------------------------------------------------

--- a/sql/pg_background.sql
+++ b/sql/pg_background.sql
@@ -897,8 +897,9 @@ END$$;
 -- -------------------------------------------------------------------------
 
 SELECT
-  workers_launched > 0   AS has_launched,
-  workers_failed >= 5    AS has_failed,
-  workers_canceled >= 1  AS has_canceled,
-  workers_active >= 0    AS has_active
+  workers_launched   > 0  AS has_launched,
+  workers_completed  > 0  AS has_completed,
+  workers_failed    >= 5  AS has_failed,
+  workers_canceled  >= 1  AS has_canceled,
+  workers_active    >= 0  AS has_active
 FROM pg_background_stats_v2();

--- a/sql/pg_background.sql
+++ b/sql/pg_background.sql
@@ -753,7 +753,7 @@ BEGIN
     h := pg_background_launch_v2('SELECT 1/0');
     PERFORM pg_background_wait_v2(h.pid, h.cookie);
     SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
-    IF s <> '22012' THEN
+    IF s IS DISTINCT FROM '22012' THEN
         RAISE EXCEPTION 'test 3.1: expected sqlstate 22012, got %', s;
     END IF;
     PERFORM pg_background_detach_v2(h.pid, h.cookie);
@@ -773,7 +773,7 @@ BEGIN
     h := pg_background_launch_v2('SELECT pgbg_test_raise_p0001()');
     PERFORM pg_background_wait_v2(h.pid, h.cookie);
     SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
-    IF s <> 'P0001' THEN
+    IF s IS DISTINCT FROM 'P0001' THEN
         RAISE EXCEPTION 'test 3.2: expected sqlstate P0001, got %', s;
     END IF;
     PERFORM pg_background_detach_v2(h.pid, h.cookie);
@@ -796,7 +796,7 @@ BEGIN
     h := pg_background_launch_v2('INSERT INTO pgbg_test_nn_23502 VALUES (NULL)');
     PERFORM pg_background_wait_v2(h.pid, h.cookie);
     SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
-    IF s <> '23502' THEN
+    IF s IS DISTINCT FROM '23502' THEN
         RAISE EXCEPTION 'test 3.3: expected sqlstate 23502, got %', s;
     END IF;
     PERFORM pg_background_detach_v2(h.pid, h.cookie);
@@ -832,7 +832,7 @@ BEGIN
     );
     PERFORM pg_background_wait_v2(h.pid, h.cookie);
     SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
-    IF s <> '23503' THEN
+    IF s IS DISTINCT FROM '23503' THEN
         RAISE EXCEPTION 'test 3.4: expected sqlstate 23503, got %', s;
     END IF;
     PERFORM pg_background_detach_v2(h.pid, h.cookie);
@@ -884,7 +884,7 @@ BEGIN
         RAISE EXCEPTION 'test 3.5: worker did not stop within 5s after cancel';
     END IF;
     SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
-    IF s <> '57014' THEN
+    IF s IS DISTINCT FROM '57014' THEN
         RAISE EXCEPTION 'test 3.5: expected sqlstate 57014, got %', s;
     END IF;
     PERFORM pg_background_detach_v2(h.pid, h.cookie);

--- a/sql/pg_background.sql
+++ b/sql/pg_background.sql
@@ -737,13 +737,168 @@ SELECT 'PASS' AS grace_bounds_test;
 SELECT 'PASS' AS detach_semantic_verified;
 
 -- -------------------------------------------------------------------------
--- Final stats check
+-- Error propagation SQLSTATE tests (v1.9 bugfix)
+--
+-- Pattern: launch_v2 -> wait_v2 -> error_info_v2 -> detach_v2
+-- Do NOT call result_v2 for error cases: it ereport(ERROR)s in launcher,
+-- which aborts the transaction and destroys error_info_v2 data.
+-- -------------------------------------------------------------------------
+
+-- Test 3.1: Division by zero — SQLSTATE 22012 (execute path)
+DO $$
+DECLARE
+    h pg_background_handle;
+    s text;
+BEGIN
+    h := pg_background_launch_v2('SELECT 1/0');
+    PERFORM pg_background_wait_v2(h.pid, h.cookie);
+    SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
+    IF s <> '22012' THEN
+        RAISE EXCEPTION 'test 3.1: expected sqlstate 22012, got %', s;
+    END IF;
+    PERFORM pg_background_detach_v2(h.pid, h.cookie);
+    RAISE NOTICE 'test 3.1 (22012 division_by_zero) OK';
+END$$;
+
+-- Test 3.2: RAISE EXCEPTION — SQLSTATE P0001 (execute path)
+-- Use a helper function instead of nested dollar-quoting to avoid psql parsing issues.
+CREATE OR REPLACE FUNCTION pgbg_test_raise_p0001() RETURNS void
+    LANGUAGE plpgsql AS 'BEGIN RAISE EXCEPTION ''custom error''; END';
+
+DO $$
+DECLARE
+    h pg_background_handle;
+    s text;
+BEGIN
+    h := pg_background_launch_v2('SELECT pgbg_test_raise_p0001()');
+    PERFORM pg_background_wait_v2(h.pid, h.cookie);
+    SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
+    IF s <> 'P0001' THEN
+        RAISE EXCEPTION 'test 3.2: expected sqlstate P0001, got %', s;
+    END IF;
+    PERFORM pg_background_detach_v2(h.pid, h.cookie);
+    RAISE NOTICE 'test 3.2 (P0001 raise_exception) OK';
+END$$;
+
+DROP FUNCTION pgbg_test_raise_p0001();
+
+-- Test 3.3: NOT NULL violation — SQLSTATE 23502 (execute path)
+-- Note: temp tables are NOT visible to background workers (separate backend).
+-- Use a regular table with a unique prefix.
+DROP TABLE IF EXISTS pgbg_test_nn_23502;
+CREATE TABLE pgbg_test_nn_23502(c int NOT NULL);
+
+DO $$
+DECLARE
+    h pg_background_handle;
+    s text;
+BEGIN
+    h := pg_background_launch_v2('INSERT INTO pgbg_test_nn_23502 VALUES (NULL)');
+    PERFORM pg_background_wait_v2(h.pid, h.cookie);
+    SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
+    IF s <> '23502' THEN
+        RAISE EXCEPTION 'test 3.3: expected sqlstate 23502, got %', s;
+    END IF;
+    PERFORM pg_background_detach_v2(h.pid, h.cookie);
+    RAISE NOTICE 'test 3.3 (23502 not_null_violation) OK';
+END$$;
+
+DROP TABLE pgbg_test_nn_23502;
+
+-- Test 3.4: Deferred FK violation — SQLSTATE 23503 (commit path)
+-- FK is INITIALLY DEFERRED, so INSERT succeeds but COMMIT fails.
+-- The error fires in the commit-wrapper PG_CATCH (Phase 2 path).
+DROP TABLE IF EXISTS pgbg_test_fk_child_23503;
+DROP TABLE IF EXISTS pgbg_test_fk_parent_23503;
+CREATE TABLE pgbg_test_fk_parent_23503(id int PRIMARY KEY);
+CREATE TABLE pgbg_test_fk_child_23503(
+    id int PRIMARY KEY,
+    parent_id int,
+    CONSTRAINT fk_23503_parent
+        FOREIGN KEY (parent_id) REFERENCES pgbg_test_fk_parent_23503(id)
+        DEFERRABLE INITIALLY DEFERRED
+);
+
+DO $$
+DECLARE
+    h pg_background_handle;
+    s text;
+BEGIN
+    -- Worker runs INSERT in its own auto-transaction.
+    -- INITIALLY DEFERRED FK fires at CommitTransactionCommand (commit-wrapper PG_CATCH).
+    -- Do NOT pass BEGIN/COMMIT: worker already runs in its own transaction.
+    h := pg_background_launch_v2(
+        'INSERT INTO pgbg_test_fk_child_23503 VALUES (1, 999)'
+    );
+    PERFORM pg_background_wait_v2(h.pid, h.cookie);
+    SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
+    IF s <> '23503' THEN
+        RAISE EXCEPTION 'test 3.4: expected sqlstate 23503, got %', s;
+    END IF;
+    PERFORM pg_background_detach_v2(h.pid, h.cookie);
+    RAISE NOTICE 'test 3.4 (23503 foreign_key_violation deferred) OK';
+END$$;
+
+DROP TABLE pgbg_test_fk_child_23503;
+DROP TABLE pgbg_test_fk_parent_23503;
+
+-- Test 3.5: Cancel — SQLSTATE 57014 (execute path, query_canceled)
+-- Uses pg_sleep(30) to ensure worker is truly sleeping before cancel.
+-- Positive sync via pg_stat_activity: cancel is only sent after the worker
+-- is confirmed to be actively executing pg_sleep. Without this sync, cancel
+-- could land before SPI_execute starts (early-failure path) and the
+-- launcher would see 08006 instead of 57014.
+DO $$
+DECLARE
+    h     pg_background_handle;
+    w_pid int4;
+    s     text;
+    done  boolean;
+    cnt   int;
+BEGIN
+    h := pg_background_launch_v2('SELECT pg_sleep(30)');
+    w_pid := h.pid;
+    /* Positive sync: let the worker fork and reach SPI_execute, then
+       confirm it is actively running via pg_stat_activity.  An initial
+       sleep gives the OS scheduler time to start the child process;
+       afterwards we poll at 100 ms intervals for up to ~5 s total. */
+    PERFORM pg_sleep(0.5);
+    FOR i IN 1..50 LOOP
+        SELECT count(*) INTO cnt
+          FROM pg_stat_activity
+         WHERE pid = w_pid
+           AND state = 'active';
+        EXIT WHEN cnt > 0;
+        PERFORM pg_sleep(0.1);
+    END LOOP;
+    IF cnt = 0 THEN
+        RAISE EXCEPTION
+            'test 3.5: worker not active within 5.5s — test not valid';
+    END IF;
+    /* Worker is past pq_redirect_to_shm_mq and executing SQL; cancel
+       will be caught by the execute-phase PG_CATCH and produce 57014. */
+    PERFORM pg_background_cancel_v2_grace(h.pid, h.cookie, 100);
+    -- Wait for worker to stop after cancel (should be fast)
+    done := pg_background_wait_v2_timeout(h.pid, h.cookie, 5000);
+    IF NOT done THEN
+        RAISE EXCEPTION 'test 3.5: worker did not stop within 5s after cancel';
+    END IF;
+    SELECT sqlstate INTO s FROM pg_background_error_info_v2(h.pid, h.cookie);
+    IF s <> '57014' THEN
+        RAISE EXCEPTION 'test 3.5: expected sqlstate 57014, got %', s;
+    END IF;
+    PERFORM pg_background_detach_v2(h.pid, h.cookie);
+    RAISE NOTICE 'test 3.5 (57014 query_canceled) OK';
+END$$;
+
+-- -------------------------------------------------------------------------
+-- Final stats check (defensive form: >= N instead of hard-coded counts)
+-- This avoids brittleness when test count changes between phases.
 -- -------------------------------------------------------------------------
 
 SELECT
-  workers_launched AS total_launched,
-  workers_completed AS total_completed,
-  workers_failed AS total_failed,
-  workers_canceled AS total_canceled,
-  workers_active AS currently_active
+  workers_launched > 0   AS has_launched,
+  workers_failed >= 5    AS has_failed,
+  workers_canceled >= 1  AS has_canceled,
+  workers_active >= 0    AS has_active
 FROM pg_background_stats_v2();

--- a/test-assert.sh
+++ b/test-assert.sh
@@ -66,14 +66,25 @@ docker exec "${CONTAINER_NAME}" bash -c "
     locale-gen
 "
 
-step "Downloading PostgreSQL ${PG_VERSION} source..."
+# Latest known patch per major version (update periodically when new patches ship).
+# The actual patch used here does not matter for assert-enabled regression
+# testing — we only care that the source tarball exists and builds. If the
+# pinned patch is ever missing from the FTP, we fall back to ${PG_VERSION}.0,
+# which is the initial release and is kept on the PG FTP permanently.
+case "${PG_VERSION}" in
+    14) PG_PATCH=18 ;;
+    15) PG_PATCH=14 ;;
+    16) PG_PATCH=10 ;;
+    17) PG_PATCH=6  ;;
+    18) PG_PATCH=2  ;;
+    *)  PG_PATCH=0  ;;
+esac
+
+step "Downloading PostgreSQL ${PG_VERSION}.${PG_PATCH} source (fallback: ${PG_VERSION}.0)..."
 docker exec "${CONTAINER_NAME}" bash -c "
     cd /tmp
-    wget -q https://ftp.postgresql.org/pub/source/v${PG_VERSION}.0/postgresql-${PG_VERSION}.0.tar.gz || \
-    wget -q https://ftp.postgresql.org/pub/source/v${PG_VERSION}.1/postgresql-${PG_VERSION}.1.tar.gz || \
-    wget -q https://ftp.postgresql.org/pub/source/v${PG_VERSION}.2/postgresql-${PG_VERSION}.2.tar.gz || \
-    wget -q https://ftp.postgresql.org/pub/source/v${PG_VERSION}.21/postgresql-${PG_VERSION}.21.tar.gz || \
-    wget -q https://ftp.postgresql.org/pub/source/v${PG_VERSION}.22/postgresql-${PG_VERSION}.22.tar.gz
+    wget -q https://ftp.postgresql.org/pub/source/v${PG_VERSION}.${PG_PATCH}/postgresql-${PG_VERSION}.${PG_PATCH}.tar.gz || \
+    wget -q https://ftp.postgresql.org/pub/source/v${PG_VERSION}.0/postgresql-${PG_VERSION}.0.tar.gz
     tar xzf postgresql-*.tar.gz
 "
 


### PR DESCRIPTION
Extracted pg_background_worker_error_exit() helper — a single pg_attribute_noreturn function that handles all three error paths (init phase, execute phase, commit phase) consistently:
                                                                                                                                                                                                        
  1. Switches to TopMemoryContext, calls CopyErrorData() (matching PostgreSQL's own ParallelWorkerMain pattern)                                                                                         
  2. Writes error fields to DSM (error_message, error_detail, error_hint, error_context)                                                                                                                
  3. Issues pg_write_barrier() then writes error_sqlstate last as the publish flag, so concurrent readers never see partial error data                                                                  
  4. Emits the real 'E' frame via EmitErrorReport() wrapped in a nested PG_TRY (mirrors ParallelWorkerMain swallow pattern — any OOM inside EmitErrorReport is caught and flushed rather than crashing  
  the worker)                                                                                                                                                                                           
  5. Calls two FlushErrorState() in sequence: the first clears any secondary error raised by EmitErrorReport; the second clears the original worker error still on the ErrorContext stack               
  6. Aborts the transaction, sends ReadyForQuery + pq_flush, and calls proc_exit(1)                                                                                                                     
                                                                                                                                                                                                        
  Restructured pg_background_worker_main into three sequential PG_TRY blocks:                                                                                                                           
                                                                                                                                                                                                        
  - Outer block: init phase (BackgroundWorkerInitializeConnection, StartTransactionCommand, RestoreGUCState, SetUserIdAndSecContext)                                                                    
  - Inner block (nested inside outer): execute phase (execute_sql_string) — errors call pg_background_worker_error_exit() and never reach the outer catch
  - Commit block (sequential, not nested): CommitTransactionCommand() — catches deferred constraints and AFTER-trigger failures                                                                         
                                                                                                                                                                                                        
  This structure ensures exactly one EmitErrorReport per error and prevents double-reporting.                                                                                                           
                                                                                                                                                                                                        
  Additional fixes:                                                                                                                                                                                     
  - HOLD_INTERRUPTS / RESUME_INTERRUPTS wrapping matches ParallelWorkerMain pattern
  - Added pq_flush() to success path (was missing; ReadyForQuery frame could be dropped before proc_exit)                                                                                               
  - Fixed pgstat_report_activity(STATE_IDLE, sql) → pgstat_report_activity(STATE_IDLE, NULL) in success path
  - Removed PG18-incompatible forward declaration (pg_attribute_noreturn on static inline)                                                                                                              
  - Replaced snprintf with strlcpy for error_sqlstate (consistent with all other field copies)                                                                                                          
  - Moved FreeErrorData(edata) to after PG_END_TRY() so EmitErrorReport can still read ErrorData fields during emission                                                                                 
  - Added Assert(fdata != NULL) as first statement in the helper                                                                                                                                        
                                                                                                                                       