### PR TITLE
fix(cancel): never SIGKILL a worker — cooperative cancel only (cluster-crash fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ SELECT * FROM pg_background_get_progress(:'h.pid', :'h.cookie');
 | `pg_background_error_info(pid, cookie)` | `pg_background_error` | Get structured error details (v1.9) | Error diagnostics |
 | `pg_background_detach(pid, cookie)` | `void` | Stop tracking worker (worker continues) | Cleanup bookkeeping |
 | `pg_background_detach_all()` | `int4` | Detach all workers in session (v1.9) | Session cleanup |
-| `pg_background_cancel(pid, cookie, grace_ms DEFAULT 0)` | `void` | Cancel via SIGTERM (`grace_ms=0`) or SIGTERM + grace + SIGKILL (`grace_ms>0`, capped at 3600000) | Terminate unwanted work |
+| `pg_background_cancel(pid, cookie, grace_ms DEFAULT 0)` | `void` | Cooperative cancel via SIGTERM; `grace_ms>0` also waits up to N ms (capped at 3600000) for the worker to stop. Never force-kills (see Limitation 10) | Terminate unwanted work |
 | `pg_background_cancel_all()` | `int4` | Cancel all workers in session (v1.9) | Emergency cleanup |
 | `pg_background_wait(pid, cookie, timeout_ms DEFAULT 0)` | `bool` | `timeout_ms<=0` blocks indefinitely (returns `true`); `>0` waits up to N ms (returns `true` if stopped, `false` on timeout) | Synchronous barrier / bounded wait |
 | `pg_background_list()` | `SETOF record` | List known workers in current session (column-definition list required) | Internal — prefer the view below |
@@ -588,7 +588,7 @@ SELECT * FROM pg_background_get_progress(:'h.pid', :'h.cookie');
 - `pid`: Process ID from handle
 - `cookie`: Unique identifier from handle (prevents PID reuse)
 - `label`: Optional worker label for identification (v1.9, default: NULL)
-- `grace_ms`: Milliseconds to wait before forceful termination (capped at 1 hour)
+- `grace_ms`: Milliseconds to wait for the worker to stop cooperatively after SIGTERM (capped at 1 hour); the worker is never force-killed
 - `timeout_ms`: Milliseconds to wait for completion
 
 **Handle Type**:
@@ -1736,58 +1736,40 @@ be `NULL`. All ordinary SQL errors (syntax, constraint violation,
 division-by-zero, `RAISE EXCEPTION`, statement cancel) propagate through the
 normal path and appear as their real SQLSTATE, not `08006`.
 
-### 10. Worker SIGSEGV in PG bgworker startup under concurrent cancel
+### 10. Cancellation is cooperative — workers are never force-killed
 
-**Limitation**: when several long-running workers are launched in close
-succession in the same session and then cancelled concurrently (e.g. via
-`pg_background_cancel_by_label` against a label pattern matching ≥2
-workers, especially with `grace_ms > 0`), one of the workers occasionally
-dies with **signal 11 (SIGSEGV)**. PostgreSQL's postmaster sees the
-abnormal exit and triggers a crash-recovery cycle, terminating the launcher
-session.
+**Behavior**: `pg_background_cancel(pid, cookie, grace_ms)` (and the
+batch/by-label variants) cancel a worker **cooperatively** by sending
+`SIGTERM`. The worker converts that into a catchable query cancel at its
+next interrupt check and exits via `proc_exit(1)`. When `grace_ms > 0` the
+launcher additionally waits up to `grace_ms` for the worker to stop, purely
+so the caller can observe whether it did. **pg_background never escalates to
+`SIGKILL`.**
 
-**Diagnostic finding (2.0)**: the segfaulting worker emits **zero log
-output** before dying — no `STATEMENT`, no `ERROR`, not even an early
-`elog(LOG, ...)` placed at the very top of `pg_background_worker_main`.
-That means the SIGSEGV occurs in PostgreSQL's background-worker startup
-machinery, **before our `worker_main` runs and before
-`pq_redirect_to_shm_mq` has installed the launcher-bound logging
-destination**. We initially suspected a race in our `error_exit`; the
-PGBG-DBG-instrumented run showed a working-but-canceled sibling worker
-walking every `error_exit` stage cleanly while the dying worker emitted
-nothing at all — so the bug is upstream of pg_background, in the PG
-bgworker setup path that runs between postmaster fork and our entry point.
+**Why no force-kill**: PostgreSQL's postmaster treats *any* child that dies
+from an uncaught signal (`SIGKILL`, `SIGSEGV`, …) as a crash and responds by
+terminating every other backend and reinitializing shared memory — a
+cluster-wide restart that drops all sessions. There is no signal that
+force-stops a background worker without tripping crash recovery, so a worker
+that ignores the cooperative cancel cannot be force-killed safely.
 
-**Reproduction**: ~75% under the in-tree regression suite on PG 17 in
-Docker with 2–4 concurrent `pg_sleep(60)` workers receiving SIGTERM in
-close succession (the previous form of the `cancel_by_label` test).
-Single-worker `cancel_by_label` does not reproduce.
+**History (fixed in 2.0)**: earlier 2.0 development builds *did* escalate to
+`kill(pid, SIGKILL)` after the grace period expired. This was benign on fast
+machines (the worker almost always exited cooperatively within `grace_ms`,
+so the `SIGKILL` never fired) but caused a hard-to-trace **cluster crash on
+slow or loaded hosts** — most visibly on the Debian/pgdg build farm and
+under Valgrind, where a worker still in PostgreSQL's bgworker *startup* path
+when the grace timer expired was `SIGKILL`ed before it ever reached
+`pg_background_worker_main`. Because `SIGKILL` is uncatchable, the dying
+worker emitted **zero log output**, which made the failure look like an
+upstream SIGSEGV in PG's startup machinery. It was not: it was this
+extension force-killing its own worker. Removing the `SIGKILL` escalation
+resolves it.
 
-**Defensive C-side fixes in 2.0** (section F): two unrelated cleanups in
-`pg_background_worker_error_exit` that match PostgreSQL's standard error
-handling pattern. They do not fix the SIGSEGV (it isn't in our code) but
-they're real correctness improvements:
-- Removed a `RESUME_INTERRUPTS()` before `proc_exit(1)` so a queued
-  second-cancel cannot be dispatched into proc_exit's cleanup chain.
-- Reordered to `EmitErrorReport → AbortCurrentTransaction → FlushErrorState`
-  (was `emit → flush → abort`, which let abort callbacks fire into an
-  empty error stack).
-
-**Workarounds for callers**:
-- Prefer `cancel(pid, cookie, 0)` (immediate SIGTERM, no grace) followed
-  by an explicit `wait(pid, cookie, timeout_ms)` for a bounded wait.
-- Stagger cancels: cancel one worker at a time rather than calling
-  `cancel_by_label` against a pattern matching many concurrent workers.
-- Set `statement_timeout` on the worker SQL so it self-cancels rather than
-  relying on cluster-side cancellation.
-
-**Status / next steps**: settling this requires a core dump from a
-reproduction (run with `ulimit -c unlimited`, install the dump path in
-`/proc/sys/kernel/core_pattern`, and inspect with `gdb`). The frame at
-the top of the stack will identify which PG infrastructure call SEGVs —
-most likely `procsignal_sigusr1_handler`, `BackgroundWorkerInitializeConnection`,
-or a `LWLock` access during early shared-memory setup, before our worker
-has installed its own SIGTERM handler.
+**Guidance for unresponsive workers**: a worker stuck in CPU-bound SQL that
+never reaches an interrupt check will not stop on cancel. Bound such work
+ahead of time with `statement_timeout` or the `pg_background.worker_timeout`
+GUC so it self-cancels.
 
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -308,7 +308,10 @@ error-cleanup sequence:
    into proc_exit's cleanup chain via `CHECK_FOR_INTERRUPTS` with no
    live `PG_TRY` to catch the resulting `ereport(ERROR)`.
 
-A residual race in PostgreSQL's BGW startup machinery (before our
-worker_main runs) can still produce a worker SIGSEGV under aggressive
-multi-worker concurrent cancel; see README "Known Limitations §10" for
-the workaround and the next-step debug recipe.
+Cancellation is cooperative only: the launcher sends SIGTERM and, for a
+non-zero grace period, waits for the worker to stop, but it never escalates
+to SIGKILL. Force-killing a bgworker would make the postmaster treat the
+death as a crash and restart the whole cluster. (Earlier 2.0 builds did
+escalate to SIGKILL after the grace period and crashed the cluster on slow
+hosts when the grace timer beat a still-starting worker; see README "Known
+Limitations §10".)

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -382,7 +382,7 @@ to use when porting.
 | `pg_background_result(pid)` → `SETOF record` | `pg_background_result_v2(pid, cookie)` → `SETOF record` | Same one-time consumption rule. Avoid calling on errored workers — use `error_info_v2` instead |
 | `pg_background_detach(pid)` → `void` | `pg_background_detach_v2(pid, cookie)` → `void` | Detach removes tracking; the worker keeps running and commits |
 | _(no equivalent)_ | `pg_background_submit_v2(sql, queue_size, label)` | Dedicated fire-and-forget; clearer than `launch + detach` |
-| _(no equivalent)_ | `pg_background_cancel_v2(pid, cookie, grace_ms)` | SIGTERM, optional grace window before SIGKILL |
+| _(no equivalent)_ | `pg_background_cancel_v2(pid, cookie, grace_ms)` | Cooperative SIGTERM; optional grace window to wait for the worker to stop (never force-killed) |
 | _(no equivalent)_ | `pg_background_wait_v2(pid, cookie, timeout_ms)` | Block until exit, optionally bounded |
 | _(no equivalent)_ | `pg_background_list_v2()` / `pg_background_list` view | Per-session worker registry with state, label, last_error |
 | _(no equivalent)_ | `pg_background_stats_v2()` | Counters: launched, completed, failed, canceled, timed_out, active, avg_execution_ms |

--- a/extension/pg_background--1.10--2.0.sql
+++ b/extension/pg_background--1.10--2.0.sql
@@ -184,8 +184,9 @@ AS 'MODULE_PATHNAME', 'pg_background_cancel'
 LANGUAGE C STRICT;
 
 COMMENT ON FUNCTION pg_background_cancel(pg_catalog.int4, pg_catalog.int8, pg_catalog.int4) IS
-'Cancel a worker. grace_ms = 0 sends SIGTERM only; grace_ms > 0 waits that '
-'many ms for clean exit before SIGKILL (capped at 1 hour).';
+'Cooperatively cancel a worker via SIGTERM. grace_ms = 0 signals and returns '
+'immediately; grace_ms > 0 also waits up to that many ms (capped at 1 hour) '
+'for the worker to stop. The worker is never force-killed.';
 
 -- single wait entrypoint with optional timeout_ms (<=0 blocks forever).
 CREATE FUNCTION pg_background_wait(

--- a/extension/pg_background--2.0.sql
+++ b/extension/pg_background--2.0.sql
@@ -131,8 +131,9 @@ AS 'MODULE_PATHNAME', 'pg_background_cancel'
 LANGUAGE C STRICT;
 
 COMMENT ON FUNCTION pg_background_cancel(pg_catalog.int4, pg_catalog.int8, pg_catalog.int4) IS
-'Cancel a worker. grace_ms = 0 sends SIGTERM only; grace_ms > 0 waits that '
-'many ms for clean exit before SIGKILL (capped at 1 hour).';
+'Cooperatively cancel a worker via SIGTERM. grace_ms = 0 signals and returns '
+'immediately; grace_ms > 0 also waits up to that many ms (capped at 1 hour) '
+'for the worker to stop. The worker is never force-killed.';
 
 -- single wait entrypoint with optional timeout_ms (<=0 blocks forever).
 CREATE FUNCTION pg_background_wait(

--- a/src/pg_background.c
+++ b/src/pg_background.c
@@ -1512,14 +1512,22 @@ pg_background_detach(PG_FUNCTION_ARGS)
  *     Cancel a background worker (v2 API).
  *
  * v2.0: Single entrypoint with optional grace_ms (defaulted in SQL to 0).
- * Sets the cancel flag and sends SIGTERM. If grace_ms > 0, waits up to
- * grace_ms milliseconds for the worker to exit cleanly before sending
- * SIGKILL. Grace period is clamped to PGBG_GRACE_MS_MAX (1 hour).
+ * Sets the cancel flag and sends SIGTERM (cooperative cancellation). If
+ * grace_ms > 0, additionally waits up to grace_ms milliseconds for the
+ * worker to stop, so the caller can observe whether it actually exited.
+ * Grace period is clamped to PGBG_GRACE_MS_MAX (1 hour).
+ *
+ * Cancellation is cooperative: we never SIGKILL the worker, because a
+ * bgworker killed by a signal forces a postmaster crash-recovery restart of
+ * the entire cluster (see pgbg_send_cancel_signals). An unresponsive worker
+ * is therefore not force-stopped; bound runaway SQL with statement_timeout
+ * or pg_background.worker_timeout instead.
  *
  * Parameters:
  *     pid      - Worker process ID
  *     cookie   - Worker identity cookie from launch
- *     grace_ms - Grace period before SIGKILL (0 = immediate SIGTERM only)
+ *     grace_ms - Time to wait for cooperative exit (0 = send SIGTERM and
+ *                return immediately, without waiting)
  */
 Datum
 pg_background_cancel(PG_FUNCTION_ARGS)
@@ -1822,12 +1830,24 @@ pgbg_request_cancel(pg_background_worker_info *info)
 
 /*
  * pgbg_send_cancel_signals
- *     Send cancellation signals to worker.
+ *     Send cancellation signal to worker.
  *
- * Sends SIGTERM for cooperative cancellation. If grace_ms > 0,
- * waits for worker to exit, then sends SIGKILL if still running.
+ * Sends SIGTERM for cooperative cancellation. If grace_ms > 0, waits up to
+ * grace_ms for the worker to stop cooperatively (exponential-backoff poll),
+ * purely so the caller can observe whether the worker actually exited.
  *
- * Uses exponential backoff polling during the grace period.
+ * We deliberately do NOT escalate to SIGKILL. The postmaster treats any
+ * child that dies from an uncaught signal (SIGKILL included) as a crash and
+ * responds by terminating every other backend and reinitializing shared
+ * memory -- a cluster-wide restart that drops all sessions. A direct
+ * SIGKILL of a background worker therefore turns a single cancel into a
+ * server crash. There is no signal that force-stops a bgworker without
+ * tripping crash recovery, so cancellation is cooperative only. This
+ * matches the documented contract (cancel requests termination; it does not
+ * guarantee an immediate stop) and the worker's own SIGTERM handler, which
+ * converts the signal into a catchable query cancel and exits via
+ * proc_exit(1) -- an exit code the postmaster accepts without crash
+ * recovery.
  */
 static void
 pgbg_send_cancel_signals(pg_background_worker_info *info, int32 grace_ms)
@@ -1870,16 +1890,13 @@ pgbg_send_cancel_signals(pg_background_worker_info *info, int32 grace_ms)
         return;
 
     /*
-     * Wait up to grace_ms for the worker to exit cooperatively.
-     * If it does not exit, escalate to SIGKILL on Unix.
+     * Best-effort: wait up to grace_ms for the worker to stop after the
+     * cooperative SIGTERM above. If it has not stopped by then we simply
+     * return -- the worker keeps running and will still honor the pending
+     * cancel at its next interrupt check. We never force-kill (see the
+     * function header for why SIGKILL would crash the whole cluster).
      */
-    if (pgbg_wait_for_stop(info, grace_ms))
-        return;
-
-#ifndef WIN32
-    if (info->pid > 0)
-        (void) kill(info->pid, SIGKILL);
-#endif
+    (void) pgbg_wait_for_stop(info, grace_ms);
 }
 
 /*


### PR DESCRIPTION
## Summary
Removes the `SIGKILL` escalation in `pgbg_send_cancel_signals`. `pg_background_cancel(pid, cookie, grace_ms)` previously escalated to `kill(pid, SIGKILL)` when a worker had not stopped within the grace window. The postmaster treats any child that dies from an uncaught signal as a crash and responds with a cluster-wide restart, so the SIGKILL turned a single cancel into a server crash.

Benign on fast machines (worker exits cooperatively within `grace_ms`, so SIGKILL never fires); deterministic crash on slow/loaded hosts — reproduced on the Debian/pgdg PG18 build farm and locally under Valgrind, where a worker still in PG's bgworker startup path when the grace timer expired was killed before reaching `pg_background_worker_main`. The uncatchable SIGKILL left the worker logging nothing, which had previously been misdiagnosed as an upstream PG SIGSEGV (README §10).

## Fix
Cancellation is now cooperative only: `SIGTERM` + (for `grace_ms > 0`) a bounded wait so the caller can observe whether the worker stopped. Matches the documented contract ("cancel requests termination; does not guarantee an immediate stop"). There is no signal that force-stops a bgworker without tripping crash recovery; bound runaway SQL with `statement_timeout` / `pg_background.worker_timeout`.

## Validation
- Standard `installcheck` passes on PG18, no expected-output change.
- The Valgrind run that previously crashed at the cancel test now completes cleanly: no abnormal worker exits; cancelled workers exit code 1, never by signal.

## Docs
Rewrote the misdiagnosed README "Known Limitations §10" and the ARCHITECTURE.md note with the real root cause; updated the cancel SQL COMMENT and MIGRATION wording to drop SIGKILL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)