### PR TITLE
fix(worker): don't ResourceOwnerDelete a NULL owner on pre-start cancel

### DIFF
--- a/expected/pg_background.out
+++ b/expected/pg_background.out
@@ -2073,6 +2073,48 @@ BEGIN
     RAISE NOTICE 'canonical launch/wait/result OK';
 END$$;
 NOTICE:  canonical launch/wait/result OK
+-- Regression guard for the pre-execution cancel branch in the worker.
+--
+-- A grace=0 cancel issued immediately after launch tries to set
+-- input->cancel_requested before the worker reaches its pre-SQL cancel check.
+-- When the worker observes the flag there it must exit via proc_exit(0) WITHOUT
+-- calling ResourceOwnerDelete(CurrentResourceOwner): the GUC-restore transaction
+-- has already committed, so CurrentResourceOwner is NULL there, and deleting a
+-- NULL owner trips Assert(owner != CurrentResourceOwner) on assert-enabled
+-- builds (observed as a worker SIGABRT on the PG19 beta PGDG assert build).
+--
+-- The race between the cancel landing and the worker reaching the check is
+-- inherent, so this is a best-effort trigger rather than a deterministic one;
+-- it is most likely to fire under the slower assert/sanitizer CI lanes, which
+-- is exactly where the crash showed up. The assertion is path-independent:
+-- whichever branch the worker takes, the launcher marked it canceled, so
+-- workers_canceled must advance by >= 1 and the worker must be gone. Single
+-- worker only (see the cancel_by_label note re: upstream multi-worker startup
+-- SIGSEGV).
+DO $$
+DECLARE
+    h               pg_background_handle;
+    before_canceled int8;
+    after_canceled  int8;
+BEGIN
+    SELECT workers_canceled INTO before_canceled FROM pg_background_stats();
+
+    h := pg_background_launch('SELECT pg_sleep(60)', 65536, 'canon-prestart-cancel');
+    /* grace_ms => 0: request immediate termination as early as possible */
+    PERFORM pg_background_cancel(h.pid, h.cookie, 0);
+
+    PERFORM pg_background_wait(h.pid, h.cookie);
+    PERFORM pg_background_detach(h.pid, h.cookie);
+
+    SELECT workers_canceled INTO after_canceled FROM pg_background_stats();
+    IF after_canceled - before_canceled < 1 THEN
+        RAISE EXCEPTION 'pre-start cancel: workers_canceled +%, want >= 1',
+            after_canceled - before_canceled;
+    END IF;
+
+    RAISE NOTICE 'canonical pre-start cancel (grace=0) OK';
+END$$;
+NOTICE:  canonical pre-start cancel (grace=0) OK
 -- run() and run_query() canonical helpers.
 SELECT (pg_background_run('SELECT 1', timeout_ms => 5000)).completed AS run_completed;
  run_completed 

--- a/expected/pg_background_1.out
+++ b/expected/pg_background_1.out
@@ -2073,6 +2073,48 @@ BEGIN
     RAISE NOTICE 'canonical launch/wait/result OK';
 END$$;
 NOTICE:  canonical launch/wait/result OK
+-- Regression guard for the pre-execution cancel branch in the worker.
+--
+-- A grace=0 cancel issued immediately after launch tries to set
+-- input->cancel_requested before the worker reaches its pre-SQL cancel check.
+-- When the worker observes the flag there it must exit via proc_exit(0) WITHOUT
+-- calling ResourceOwnerDelete(CurrentResourceOwner): the GUC-restore transaction
+-- has already committed, so CurrentResourceOwner is NULL there, and deleting a
+-- NULL owner trips Assert(owner != CurrentResourceOwner) on assert-enabled
+-- builds (observed as a worker SIGABRT on the PG19 beta PGDG assert build).
+--
+-- The race between the cancel landing and the worker reaching the check is
+-- inherent, so this is a best-effort trigger rather than a deterministic one;
+-- it is most likely to fire under the slower assert/sanitizer CI lanes, which
+-- is exactly where the crash showed up. The assertion is path-independent:
+-- whichever branch the worker takes, the launcher marked it canceled, so
+-- workers_canceled must advance by >= 1 and the worker must be gone. Single
+-- worker only (see the cancel_by_label note re: upstream multi-worker startup
+-- SIGSEGV).
+DO $$
+DECLARE
+    h               pg_background_handle;
+    before_canceled int8;
+    after_canceled  int8;
+BEGIN
+    SELECT workers_canceled INTO before_canceled FROM pg_background_stats();
+
+    h := pg_background_launch('SELECT pg_sleep(60)', 65536, 'canon-prestart-cancel');
+    /* grace_ms => 0: request immediate termination as early as possible */
+    PERFORM pg_background_cancel(h.pid, h.cookie, 0);
+
+    PERFORM pg_background_wait(h.pid, h.cookie);
+    PERFORM pg_background_detach(h.pid, h.cookie);
+
+    SELECT workers_canceled INTO after_canceled FROM pg_background_stats();
+    IF after_canceled - before_canceled < 1 THEN
+        RAISE EXCEPTION 'pre-start cancel: workers_canceled +%, want >= 1',
+            after_canceled - before_canceled;
+    END IF;
+
+    RAISE NOTICE 'canonical pre-start cancel (grace=0) OK';
+END$$;
+NOTICE:  canonical pre-start cancel (grace=0) OK
 -- run() and run_query() canonical helpers.
 SELECT (pg_background_run('SELECT 1', timeout_ms => 5000)).completed AS run_completed;
  run_completed 

--- a/sql/pg_background.sql
+++ b/sql/pg_background.sql
@@ -1749,6 +1749,48 @@ BEGIN
     RAISE NOTICE 'canonical launch/wait/result OK';
 END$$;
 
+-- Regression guard for the pre-execution cancel branch in the worker.
+--
+-- A grace=0 cancel issued immediately after launch tries to set
+-- input->cancel_requested before the worker reaches its pre-SQL cancel check.
+-- When the worker observes the flag there it must exit via proc_exit(0) WITHOUT
+-- calling ResourceOwnerDelete(CurrentResourceOwner): the GUC-restore transaction
+-- has already committed, so CurrentResourceOwner is NULL there, and deleting a
+-- NULL owner trips Assert(owner != CurrentResourceOwner) on assert-enabled
+-- builds (observed as a worker SIGABRT on the PG19 beta PGDG assert build).
+--
+-- The race between the cancel landing and the worker reaching the check is
+-- inherent, so this is a best-effort trigger rather than a deterministic one;
+-- it is most likely to fire under the slower assert/sanitizer CI lanes, which
+-- is exactly where the crash showed up. The assertion is path-independent:
+-- whichever branch the worker takes, the launcher marked it canceled, so
+-- workers_canceled must advance by >= 1 and the worker must be gone. Single
+-- worker only (see the cancel_by_label note re: upstream multi-worker startup
+-- SIGSEGV).
+DO $$
+DECLARE
+    h               pg_background_handle;
+    before_canceled int8;
+    after_canceled  int8;
+BEGIN
+    SELECT workers_canceled INTO before_canceled FROM pg_background_stats();
+
+    h := pg_background_launch('SELECT pg_sleep(60)', 65536, 'canon-prestart-cancel');
+    /* grace_ms => 0: request immediate termination as early as possible */
+    PERFORM pg_background_cancel(h.pid, h.cookie, 0);
+
+    PERFORM pg_background_wait(h.pid, h.cookie);
+    PERFORM pg_background_detach(h.pid, h.cookie);
+
+    SELECT workers_canceled INTO after_canceled FROM pg_background_stats();
+    IF after_canceled - before_canceled < 1 THEN
+        RAISE EXCEPTION 'pre-start cancel: workers_canceled +%, want >= 1',
+            after_canceled - before_canceled;
+    END IF;
+
+    RAISE NOTICE 'canonical pre-start cancel (grace=0) OK';
+END$$;
+
 -- run() and run_query() canonical helpers.
 SELECT (pg_background_run('SELECT 1', timeout_ms => 5000)).completed AS run_completed;
 SELECT * FROM pg_background_run_query('SELECT 42 AS n', timeout_ms => 5000, col_def => 'n int') AS r(n int);

--- a/src/pg_background_worker.c
+++ b/src/pg_background_worker.c
@@ -376,8 +376,14 @@ pg_background_worker_main(Datum main_arg)
         /* If cancel was requested before we began, exit quietly */
         if (*(volatile uint32 *)&input->cancel_requested != 0)
         {
-            ResourceOwnerDelete(CurrentResourceOwner);
-            CurrentResourceOwner = NULL;
+            /*
+             * The GUC-restore transaction above already committed, which
+             * resets CurrentResourceOwner to NULL, so there is nothing to
+             * delete here. Calling ResourceOwnerDelete(CurrentResourceOwner)
+             * with a NULL owner trips the Assert(owner != CurrentResourceOwner)
+             * in assert-enabled builds. proc_exit() performs the remaining
+             * shutdown cleanup, including the worker's startup ResourceOwner.
+             */
             proc_exit(0);
         }
 


### PR DESCRIPTION
## Problem

The early-cancel path in `pg_background_worker_main` called `ResourceOwnerDelete(CurrentResourceOwner)` when a cancel was requested before execution began. By that point the GUC-restore transaction has already committed, which resets `CurrentResourceOwner` to `NULL`. Passing `NULL` to `ResourceOwnerDelete` trips its `Assert(owner != CurrentResourceOwner)` (`NULL != NULL`) in assert-enabled builds, crashing the worker with `SIGABRT`.

This surfaced on the **PG19 beta PGDG assert-enabled build** (`TRAP: failed Assert("owner != CurrentResourceOwner")` at `pg_background_worker.c:379`). It did not appear in the regular installcheck matrix (PG14–18, no `--enable-cassert`).

## Fix

Drop the manual `ResourceOwnerDelete` and let `proc_exit(0)` perform shutdown cleanup, matching the guarded cleanup already used on the normal exit path. No observable SQL behavior change — the worker still exits quietly on pre-start cancel.

## Validation

All Docker suites pass against the working tree:

| Suite | Versions | Result |
|---|---|---|
| `test-local.sh all` | 14–19 | ✅ |
| `test-assert.sh` (cassert) | 18 | ✅ (the bug's repro class) |
| `test-relocatable.sh` | 19 | ✅ 28 PASS / 0 FAIL |
| `test-upgrade.sh` | 18 | ✅ |
| `test-sanitizer.sh` (ASan+UBSan) | 18 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)